### PR TITLE
Consume Docker Hub upstream SBOMs and merge with Syft

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Most Docker Official Images (`library/*` — `python`, `nginx`, `postgres`, etc.
 1. **Direct** — `DOCKER_IMAGE` is itself a Docker Official Image (`python:3.11-slim`, `library/nginx`, `ubuntu:24.04`, …) or a DHI (`dhi.io/python:3.11`)
 2. **Provenance** — `DOCKER_IMAGE` is a user image built with BuildKit `--provenance=mode=max`, and its provenance records a Docker Hub base
 
-Merged components carry a `sbomify:source` property (`docker-hub-upstream` or `syft-overlay`) so consumers can see which half of the merge each package came from.
+In CycloneDX output, merged components carry a `sbomify:source` property (`docker-hub-upstream` or `syft-overlay`) so consumers can see which half of the merge each package came from. SPDX output is merged too, but does not currently include an equivalent per-package source annotation.
 
 ```yaml
 - uses: sbomify/sbomify-action@master

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 - **Generate** SBOMs from lockfiles (Python, Node, Rust, Go, Ruby, Dart, C++) in CycloneDX or SPDX format
 - **Generate** SBOMs from Docker images
 - **Chainguard SBOM reuse** — Automatically detects Chainguard base images and uses their provided SBOMs instead of scanning
+- **Docker Hub SBOM reuse** — Automatically detects Docker Official Images and Docker Hardened Images and merges their published SBOMs with a local Syft scan (keeps publisher metadata for base packages, still captures what you install on top)
 - **Yocto/OpenEmbedded** — Batch process SPDX SBOMs from Yocto builds (extract, upload, release-tag)
 - **Inject** additional packages not in lockfiles (vendored code, runtime deps, system libraries)
 - **Augment** with business metadata (supplier, authors, licenses, lifecycle phase) from config file or sbomify
@@ -122,6 +123,34 @@ No configuration needed—just point `DOCKER_IMAGE` at your image:
 ```
 
 > **Note:** Chainguard detection requires `crane` and `cosign` CLI tools. Both are bundled in the Docker image. For pip installations, install them separately (see [Required Tools](#required-tools)).
+
+### Docker Hub Images
+
+Most Docker Official Images (`library/*` — `python`, `nginx`, `postgres`, etc.) and all Docker Hardened Images (`dhi.io/*`) ship with signed SPDX SBOMs attached. sbomify detects this and **merges** the publisher's authoritative SBOM with a local Syft scan of the same image. Upstream wins on conflict for the packages it covers; Syft fills in the packages your `RUN apt-get install ...` / `RUN pip install ...` adds on top.
+
+**Detection works two ways, same as Chainguard:**
+
+1. **Direct** — `DOCKER_IMAGE` is itself a Docker Official Image (`python:3.11-slim`, `library/nginx`, `ubuntu:24.04`, …) or a DHI (`dhi.io/python:3.11`)
+2. **Provenance** — `DOCKER_IMAGE` is a user image built with BuildKit `--provenance=mode=max`, and its provenance records a Docker Hub base
+
+Merged components carry a `sbomify:source` property (`docker-hub-upstream` or `syft-overlay`) so consumers can see which half of the merge each package came from.
+
+```yaml
+- uses: sbomify/sbomify-action@master
+  env:
+    DOCKER_IMAGE: python:3.11-slim       # or a user image built FROM python:3.11-slim
+    OUTPUT_FILE: sbom.cdx.json
+    UPLOAD: false
+    ENRICH: true
+```
+
+Supported ecosystems (tested): `pkg:deb/*` (Debian, Ubuntu), `pkg:apk/*` (Alpine), `pkg:rpm/*` (Rocky, AlmaLinux, Fedora, Amazon Linux, Oracle), `pkg:alpm/*` (Arch), plus edge cases like `busybox`. Ecosystems dedup across upstream's and Syft's different qualifier/namespace conventions automatically (e.g., upstream `pkg:rpm/amazonlinux/bash` ↔ Syft `pkg:rpm/amzn/bash`).
+
+> **Rate limits:** Anonymous Docker Hub pulls are capped at 100 manifest requests per 6 hours per IP. Each detection + fetch uses ~3 requests. Run `docker login` with a free Docker Hub account to raise this to 200/6h, or use a paid plan for unlimited. When a rate limit, 401, or 404 is hit, sbomify logs a WARNING with the remediation and falls back to a plain Syft scan.
+
+> **Docker Hardened Images (DHI)**: cosign-signed with Docker's scout keyring, not logged to public Rekor. sbomify verifies with `--insecure-ignore-tlog=true` against Docker's published key. DHI images are served from a separate registry (`dhi.io`), so authenticating to Docker Hub alone is not enough — you need to run `docker login dhi.io` with the same Docker Hub credentials, and your account must have the (free) [Docker Hardened Images](https://hub.docker.com/hardened-images) entitlement.
+
+> **BuildKit vs. sbomify:** If you already build with `docker buildx build --sbom=true`, BuildKit attaches a complete SBOM of your final image — sbomify isn't needed for generation. This feature targets the common case of `--provenance=true --sbom=false`, where BuildKit records the base image but no full SBOM is attached.
 
 <details>
 <summary><strong>More examples</strong> (augmentation, SPDX, attestation, additional packages...)</summary>
@@ -983,8 +1012,8 @@ When installed via pip, sbomify-action requires external SBOM generators. The Do
 | **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
 | **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
 | **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
-| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
-| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard and Docker Hub image detection + SBOM fetch; macOS: `brew install crane`                               |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard and Docker Hardened Images (DHI) SBOM retrieval; macOS: `brew install cosign`                          |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 

--- a/examples/docker-hub/Dockerfile.dhi
+++ b/examples/docker-hub/Dockerfile.dhi
@@ -1,0 +1,23 @@
+# Sample user image built on a Docker Hardened Image (DHI).
+#
+# Scenario: same shape as the Official variant, but the base is a cosign-signed
+# DHI image. sbomify-action should detect dhi.io/python as the base and fetch
+# its SBOM via cosign (with Docker's scout keyring + --insecure-ignore-tlog).
+#
+# Build with:
+#   docker buildx build --sbom=false --provenance=mode=max \
+#     -t localhost:5000/sbomify-test/app-dhi:latest \
+#     --push -f Dockerfile.dhi .
+#
+# NOTE: DHI images require a (free) Docker Hub account with the Hardened
+# Images entitlement to pull. If the pull fails with "repository dhi.io/python
+# not found", this Dockerfile is documentation only — the E2E runner skips
+# it and covers DHI fetch via unit tests.
+
+FROM dhi.io/python:3.11
+
+RUN pip install --no-cache-dir requests==2.32.3 click==8.1.7
+
+WORKDIR /app
+COPY hello.py ./
+CMD ["python", "hello.py"]

--- a/examples/docker-hub/Dockerfile.official
+++ b/examples/docker-hub/Dockerfile.official
@@ -1,0 +1,29 @@
+# Sample user image built on a Docker Hub Official Image.
+#
+# Scenario: a Python app with both apt and pip installs on top of the base.
+# sbomify-action should detect the `library/python` base via BuildKit SLSA
+# provenance, fetch Docker Hub's upstream SPDX SBOM for the base layers, and
+# overlay the user-installed packages via Syft.
+#
+# Build with:
+#   docker buildx build --sbom=false --provenance=mode=max \
+#     -t localhost:5000/sbomify-test/app-official:latest \
+#     --push -f Dockerfile.official .
+#
+# Note: --sbom=false so BuildKit does NOT attach its own full-image SBOM —
+# we want sbomify-action to fetch the BASE image's SBOM (from library/python)
+# and overlay Syft on top.
+
+FROM python:3.11-slim
+
+# apt packages the user installs on top of the base
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python packages the user installs
+RUN pip install --no-cache-dir requests==2.32.3 click==8.1.7
+
+WORKDIR /app
+COPY hello.py ./
+CMD ["python", "hello.py"]

--- a/examples/docker-hub/README.md
+++ b/examples/docker-hub/README.md
@@ -1,0 +1,47 @@
+# Docker Hub upstream SBOM examples
+
+End-to-end verification for the Docker Hub SBOM consumption feature. Covers
+the direct path (user image _is_ a Docker Official / DHI image) and the
+provenance path (user image was built FROM a Docker Hub base).
+
+## Scenarios
+
+| Dockerfile | Base image | What's tested |
+|---|---|---|
+| _(no file)_ | `python:3.11-slim` directly | Direct detection of a Docker Official Image, SBOM fetch via crane, merge with Syft |
+| `Dockerfile.official` | `python:3.11-slim` | Provenance-based detection of a `library/*` base, SBOM fetch + merge |
+| `Dockerfile.dhi` | `dhi.io/python:3.11` | DHI base detection + cosign-verified SBOM fetch |
+
+## Requirements
+
+- `docker` + `docker buildx` (default builder supports BuildKit v0.22+)
+- `crane`, `cosign`, `syft` on `PATH` (or run from inside the sbomify-action image)
+- A local registry to push to: `docker run -d -p 5000:5000 --name sbomify-registry registry:2`
+- `docker login` with a Docker Hub account (free). Two reasons:
+  - **Rate limits.** Anonymous pulls are capped at 100 manifest requests / 6 hours / IP. Each image scan uses ~3 requests, so a single run through all scenarios will exhaust the limit. A free Docker Hub account raises the limit to 200/6h; paid plans lift it entirely.
+  - **DHI access.** Docker Hardened Images (`dhi.io/*`) require a logged-in Docker Hub account even though the images themselves are free.
+
+## Running
+
+```bash
+./run-e2e.sh
+```
+
+The script builds each sample with `--provenance=mode=max --sbom=false`, pushes to
+the local registry, runs `sbomify-action` against it, and summarises:
+
+- Whether the Docker Hub branch fired (detection + SBOM fetch)
+- Count of `docker-hub-upstream`-tagged vs `syft-overlay`-tagged components
+- Whether the user-installed packages (`requests`, `click`, `curl`, `jq`) show up as overlays
+
+See the script for exit codes and precise assertions.
+
+## Why `--sbom=false`
+
+BuildKit can attach its own whole-image SBOM when a user image is built with
+`--sbom=true`. In that case the resulting image _already_ has a complete SBOM
+attached, and sbomify-action could theoretically consume that directly. The
+interesting case — and what this feature targets — is when a user's image has
+build _provenance_ (naming its base image) but no full SBOM of its own, which
+is the shape produced by `--provenance=mode=max --sbom=false`. That's the
+default for many CI/CD setups and what this runner exercises.

--- a/examples/docker-hub/hello.py
+++ b/examples/docker-hub/hello.py
@@ -1,0 +1,12 @@
+import click
+import requests
+
+
+@click.command()
+def main() -> None:
+    r = requests.get("https://example.com", timeout=5)
+    click.echo(f"status={r.status_code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/docker-hub/run-e2e.sh
+++ b/examples/docker-hub/run-e2e.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# End-to-end verification for Docker Hub SBOM consumption.
+#
+# Exercises:
+#   1. Direct path — scan python:3.11-slim directly.
+#   2. Provenance path — build a derivative image with BuildKit provenance,
+#      push to a local registry, scan.
+#   3. DHI path — best effort; skipped if dhi.io requires credentials.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTDIR="${OUTDIR:-$(mktemp -d)}"
+REGISTRY="${REGISTRY:-localhost:5000}"
+
+echo "=== sbomify-action Docker Hub E2E ==="
+echo "Output dir: $OUTDIR"
+echo "Registry:   $REGISTRY"
+echo
+
+# --- Prereqs ---------------------------------------------------------------
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FATAL: $1 not found on PATH" >&2; exit 2; }; }
+need docker
+need crane
+need cosign
+need syft
+need python3
+
+ACTION=(uv --project "$REPO_ROOT" run sbomify-action)
+
+ensure_registry() {
+    if curl -sf "http://$REGISTRY/v2/" >/dev/null 2>&1; then
+        return
+    fi
+    echo "Starting local registry on $REGISTRY..."
+    docker run -d -p "${REGISTRY##*:}:5000" --name sbomify-registry --restart=always registry:2 >/dev/null
+    for _ in 1 2 3 4 5; do
+        sleep 1
+        curl -sf "http://$REGISTRY/v2/" >/dev/null 2>&1 && return
+    done
+    echo "FATAL: registry not reachable at $REGISTRY" >&2
+    exit 2
+}
+
+# --- Assertions ------------------------------------------------------------
+
+assert_cdx_summary() {
+    local out="$1"
+    local min_upstream="${2:-1}"
+    python3 - "$out" "$min_upstream" <<'PY'
+import json, sys
+
+path, min_up = sys.argv[1], int(sys.argv[2])
+with open(path) as f:
+    bom = json.load(f)
+
+components = bom.get("components", [])
+sources = {}
+for c in components:
+    src = "(untagged)"
+    for p in c.get("properties", []) or []:
+        if p.get("name") == "sbomify:source":
+            src = p.get("value")
+            break
+    sources[src] = sources.get(src, 0) + 1
+
+upstream = sources.get("docker-hub-upstream", 0)
+overlay = sources.get("syft-overlay", 0)
+print(f"  upstream={upstream}  syft-overlay={overlay}  total={len(components)}")
+
+if upstream < min_up:
+    print(f"FAIL: expected >= {min_up} upstream components, got {upstream}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+assert_spdx_valid() {
+    # Validates that the SPDX output parses cleanly and has no dangling
+    # license references, plus that it has the expected upstream + overlay
+    # shape. Runs through the project's uv env so spdx-tools is available.
+    local out="$1"
+    local min_packages="${2:-10}"
+    (cd "$REPO_ROOT" && uv run python - "$out" "$min_packages") <<'PY'
+import sys
+from spdx_tools.spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+
+path, min_pkgs = sys.argv[1], int(sys.argv[2])
+doc = parse_file(path)
+errs = validate_full_spdx_document(doc)
+print(
+    f"  packages={len(doc.packages)} files={len(doc.files)} "
+    f"rel={len(doc.relationships)} ext-lic={len(doc.extracted_licensing_info)} "
+    f"validation-errors={len(errs)}"
+)
+if errs:
+    for e in errs[:3]:
+        print(f"    {str(e)[:120]}", file=sys.stderr)
+    sys.exit(1)
+if len(doc.packages) < min_pkgs:
+    print(f"FAIL: expected >= {min_pkgs} packages, got {len(doc.packages)}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+assert_packages_present() {
+    local out="$1"; shift
+    python3 - "$out" "$@" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+targets = sys.argv[2:]
+with open(path) as f:
+    bom = json.load(f)
+
+# CycloneDX: iterate components[].name; SPDX: iterate packages[].name.
+names = {c.get("name", "").lower() for c in bom.get("components", [])}
+names |= {p.get("name", "").lower() for p in bom.get("packages", [])}
+
+missing = [t for t in targets if t.lower() not in names]
+if missing:
+    print(f"FAIL: expected packages missing: {missing}", file=sys.stderr)
+    sys.exit(1)
+print(f"  confirmed present: {', '.join(targets)}")
+PY
+}
+
+# --- Scenario 1: direct path, CycloneDX (Debian-based) --------------------
+
+scenario_direct_cdx() {
+    echo "--- Scenario 1: direct Docker Official Image (python:3.11-slim, CycloneDX) ---"
+    local out="$OUTDIR/direct.cdx.json"
+    "${ACTION[@]}" --docker-image python:3.11-slim \
+        --no-upload --no-enrich \
+        -o "$out" 2>&1 | sed 's/^/  /' | tail -4
+    assert_cdx_summary "$out" 100  # python base has ~142 upstream packages
+    echo "  PASS"
+    echo
+}
+
+# --- Scenario 2: direct path, SPDX ----------------------------------------
+
+scenario_direct_spdx() {
+    echo "--- Scenario 2: direct Docker Official Image (python:3.11-slim, SPDX) ---"
+    local out="$OUTDIR/direct.spdx.json"
+    "${ACTION[@]}" --docker-image python:3.11-slim \
+        --no-upload --no-enrich \
+        -f spdx -o "$out" 2>&1 | sed 's/^/  /' | tail -4
+    assert_spdx_valid "$out" 100
+    echo "  PASS"
+    echo
+}
+
+# --- Scenario 3: Distro sweep -- various Docker Hub Official Images --------
+
+scenario_distros() {
+    echo "--- Scenario 3: Distro sweep (apk/deb/rpm/alpm ecosystems) ---"
+    # (image, purl-type-expected, min-upstream)
+    local cases=(
+        "alpine:3.20|pkg:apk|10"
+        "ubuntu:24.04|pkg:deb|100"
+        "rockylinux:9|pkg:rpm|100"
+        "amazonlinux:2|pkg:rpm|100"
+        "archlinux:latest|pkg:alpm|100"
+        "busybox:latest|pkg:generic|1"
+    )
+    for c in "${cases[@]}"; do
+        local img="${c%%|*}"
+        local rest="${c#*|}"
+        local expected_purl="${rest%%|*}"
+        local min_up="${rest##*|}"
+
+        echo "  • $img (expect $expected_purl, >=$min_up upstream)"
+        local out="$OUTDIR/${img//[:\/]/-}.cdx.json"
+        "${ACTION[@]}" --docker-image "$img" --no-upload --no-enrich -o "$out" 2>&1 \
+            | grep -iE "Fetched upstream SBOM" | sed 's/^/      /'
+        assert_cdx_summary "$out" "$min_up" | sed 's/^/    /'
+    done
+    echo "  PASS (all distros)"
+    echo
+}
+
+# --- Scenario 4: provenance path, CycloneDX -------------------------------
+
+scenario_provenance_cdx() {
+    echo "--- Scenario 4: provenance-based detection (FROM python:3.11-slim, CycloneDX) ---"
+    ensure_registry
+
+    local tag="$REGISTRY/sbomify-test/app-official:e2e-cdx-$$"
+    echo "  Building & pushing $tag (with --provenance=mode=max --sbom=false)..."
+    docker buildx build --sbom=false --provenance=mode=max \
+        -t "$tag" --push \
+        -f "$SCRIPT_DIR/Dockerfile.official" "$SCRIPT_DIR" 2>&1 | tail -3 | sed 's/^/    /'
+
+    local out="$OUTDIR/provenance.cdx.json"
+    "${ACTION[@]}" --docker-image "$tag" \
+        --no-upload --no-enrich \
+        -o "$out" 2>&1 | sed 's/^/  /' | tail -4
+    assert_cdx_summary "$out" 100
+    assert_packages_present "$out" requests click curl jq
+    echo "  PASS"
+    echo
+}
+
+# --- Scenario 5: provenance path, SPDX ------------------------------------
+
+scenario_provenance_spdx() {
+    echo "--- Scenario 5: provenance-based detection (FROM python:3.11-slim, SPDX) ---"
+    ensure_registry
+
+    local tag="$REGISTRY/sbomify-test/app-official:e2e-spdx-$$"
+    echo "  Building & pushing $tag (with --provenance=mode=max --sbom=false)..."
+    docker buildx build --sbom=false --provenance=mode=max \
+        -t "$tag" --push \
+        -f "$SCRIPT_DIR/Dockerfile.official" "$SCRIPT_DIR" 2>&1 | tail -3 | sed 's/^/    /'
+
+    local out="$OUTDIR/provenance.spdx.json"
+    "${ACTION[@]}" --docker-image "$tag" \
+        --no-upload --no-enrich \
+        -f spdx -o "$out" 2>&1 | sed 's/^/  /' | tail -4
+    assert_spdx_valid "$out" 150
+    assert_packages_present "$out" requests click curl jq
+    echo "  PASS"
+    echo
+}
+
+# --- Scenario 6: Full augment + enrich pipeline ---------------------------
+# Exercises merge → augmentation (from local sbomify.json) → enrichment
+# (PyPI/Debian/license-db live).
+
+scenario_full_pipeline() {
+    echo "--- Scenario 6: full pipeline — merge + augment + enrich (python:3.11-slim) ---"
+    local workdir="$OUTDIR/augment"
+    mkdir -p "$workdir"
+    cat > "$workdir/sbomify.json" <<'JSON'
+{
+  "lifecycle_phase": "build",
+  "supplier": {
+    "name": "sbomify E2E Test",
+    "url": ["https://sbomify.com"],
+    "contacts": [{"name": "sbomify team", "email": "team@sbomify.example"}]
+  },
+  "authors": [{"name": "sbomify-action CI", "email": "ci@sbomify.example"}],
+  "licenses": ["MIT"],
+  "release_date": "2026-04-24",
+  "support_period_end": "2028-04-24"
+}
+JSON
+    local out="$workdir/full.cdx.json"
+    (cd "$workdir" && "${ACTION[@]}" --docker-image python:3.11-slim \
+        --no-upload --augment --enrich -o "$out") 2>&1 | tail -4 | sed 's/^/  /'
+    assert_cdx_summary "$out" 100
+    python3 - "$out" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    bom = json.load(f)
+md = bom.get("metadata", {})
+assert md.get("supplier", {}).get("name") == "sbomify E2E Test", f"supplier not applied: {md.get('supplier')}"
+assert any(a.get("email") == "ci@sbomify.example" for a in md.get("authors", [])), f"author not applied"
+assert any(phase.get("phase") == "build" for phase in md.get("lifecycles", [])), f"lifecycle not applied"
+print("  augmentation applied: supplier + authors + lifecycle ✓")
+PY
+    echo "  PASS"
+    echo
+}
+
+# --- Scenario 7: DHI path -------------------------------------------------
+
+scenario_dhi() {
+    echo "--- Scenario 7: DHI base ---"
+    local manifest_err
+    manifest_err="$(crane manifest "dhi.io/python:3.11" 2>&1 >/dev/null || true)"
+    if [[ -n "$manifest_err" ]]; then
+        echo "  SKIP: dhi.io/python not pullable with current credentials."
+        if [[ "$manifest_err" == *"No matching credentials"* ]]; then
+            echo "    Cause: docker.io credentials don't apply to dhi.io (separate registry)."
+            echo "    Fix:   docker login dhi.io   (same Docker Hub username, same PAT)"
+        elif [[ "$manifest_err" == *"401"* ]] || [[ "$manifest_err" == *"Unauthorized"* ]]; then
+            echo "    Cause: logged-in account doesn't have DHI entitlement."
+            echo "    Fix:   subscribe to Docker Hardened Images at"
+            echo "           https://hub.docker.com/hardened-images (free)"
+        else
+            echo "    crane said: ${manifest_err:0:200}"
+        fi
+        echo "  Unit tests (tests/test_dockerhub.py::TestFetchDockerhubSbom::test_dhi_*) cover"
+        echo "  the cosign fetch shape including --key and --insecure-ignore-tlog=true."
+        echo
+        return
+    fi
+
+    local out="$OUTDIR/dhi.cdx.json"
+    "${ACTION[@]}" --docker-image dhi.io/python:3.11 \
+        --no-upload --no-enrich \
+        -o "$out" 2>&1 | sed 's/^/  /' | tail -4
+    assert_cdx_summary "$out" 1
+    echo "  PASS"
+    echo
+}
+
+scenario_direct_cdx
+scenario_direct_spdx
+scenario_distros
+scenario_provenance_cdx
+scenario_provenance_spdx
+scenario_full_pipeline
+scenario_dhi
+
+echo "=== all scenarios complete ==="
+echo "Outputs in $OUTDIR"

--- a/sbomify_action/_generation/buildkit_provenance.py
+++ b/sbomify_action/_generation/buildkit_provenance.py
@@ -80,6 +80,13 @@ def cosign_available() -> bool:
 def _classify_registry_error(stderr: str) -> str | None:
     """Return a human-friendly hint for common registry error shapes.
 
+    Kept registry-agnostic: this helper is shared by crane/cosign invocations
+    against Chainguard (``cgr.dev``), Docker Hub (``docker.io``), Docker
+    Hardened Images (``dhi.io``), and any other registry those tools reach.
+    Caller context (the image ref, the registry host) is not threaded in here
+    — hints stay generic but point at ``docker login <registry>`` with the
+    placeholder left for the user to fill in based on their own command.
+
     Returns ``None`` when the stderr doesn't match a known pattern — callers
     can then log the raw message.
     """
@@ -88,12 +95,29 @@ def _classify_registry_error(stderr: str) -> str | None:
     low = stderr.lower()
     if "toomanyrequests" in low or "rate limit" in low or "429" in low:
         return (
-            "Docker Hub anonymous pull rate limit exceeded (100 pulls / 6h). "
-            "Run `docker login` to raise the limit to 200/6h (free account) or "
-            "unlimited (paid)."
+            "Registry rate limit exceeded (HTTP 429). Authenticate with "
+            "`docker login <registry>` for a higher quota, or retry later. "
+            "(Docker Hub anonymous pulls are capped at 100 per 6h per IP; "
+            "authenticated free accounts get 200.)"
+        )
+    if "no matching credentials" in low:
+        # crane emits this when it can't find creds for the registry — distinct
+        # from a 401 because it never even tried to authenticate. Common cause:
+        # `docker login docker.io` doesn't grant access to `dhi.io` (separate
+        # registry, same account).
+        return (
+            "No credentials found for the target registry — run "
+            "`docker login <registry>`. Docker Hardened Images live at "
+            "`dhi.io`, which needs `docker login dhi.io` separately from "
+            "`docker login` (same Docker Hub credentials)."
         )
     if "401" in low and "unauthorized" in low:
-        return "Registry returned 401 Unauthorized — run `docker login` to authenticate."
+        return (
+            "Registry returned 401 Unauthorized. Run `docker login "
+            "<registry>` to authenticate. For DHI, use `docker login dhi.io` "
+            "and ensure your account is enrolled at "
+            "https://hub.docker.com/hardened-images (free)."
+        )
     if "not found" in low or "404" in low:
         return "Registry manifest not found (image may not exist or tag has moved)."
     return None
@@ -352,8 +376,9 @@ def iter_resolved_dependencies(statement: dict[str, Any]) -> Iterator[dict[str, 
 def fetch_cosign_spdx_predicate(
     image_with_digest: str,
     extra_cosign_args: list[str] | None = None,
+    verify: bool = False,
 ) -> dict[str, Any] | None:
-    """Run ``cosign download attestation`` and extract the SPDX predicate.
+    """Fetch (and optionally verify) the SPDX predicate from a cosign attestation.
 
     ``cosign`` emits one JSON DSSE envelope per line. Each envelope has a
     base64-encoded ``payload`` that is the in-toto statement. We scan for a
@@ -363,8 +388,18 @@ def fetch_cosign_spdx_predicate(
     ``extra_cosign_args`` are inserted before the image reference; use this
     to pass keys / tlog flags for signed-but-not-Rekor-logged attestations
     (e.g., Docker Hardened Images).
+
+    When ``verify=True`` the command switches from ``cosign download
+    attestation`` (fetch-only) to ``cosign verify-attestation --type
+    spdxjson`` (fetch + signature check). Callers that have a trust anchor
+    (a public key or a certificate identity) should set ``verify=True`` —
+    otherwise tampered attestations will be silently consumed. The output
+    format is identical in both modes, so parsing is unchanged.
     """
-    args = ["download", "attestation"]
+    if verify:
+        args = ["verify-attestation", "--type", "spdxjson"]
+    else:
+        args = ["download", "attestation"]
     if extra_cosign_args:
         args.extend(extra_cosign_args)
     args.append(image_with_digest)

--- a/sbomify_action/_generation/buildkit_provenance.py
+++ b/sbomify_action/_generation/buildkit_provenance.py
@@ -1,0 +1,404 @@
+"""BuildKit / in-toto attestation helpers shared across base-image detectors.
+
+BuildKit attaches in-toto attestations (SLSA provenance, SPDX SBOMs, etc.) to
+images as sibling manifests in the image index, annotated with
+``vnd.docker.reference.type=attestation-manifest``. Each layer of that
+manifest is one in-toto statement, annotated with ``in-toto.io/predicate-type``.
+
+Two delivery mechanisms are supported:
+
+* **Crane** walks the OCI image index directly — used for Docker Official
+  Images and BuildKit-built user images where attestations are attached as
+  siblings (unsigned).
+* **Cosign** reads DSSE envelopes produced by ``cosign attest`` — used for
+  Chainguard and Docker Hardened Images where attestations are cosign-signed.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import platform
+import shutil
+import subprocess
+from typing import Any, Iterator
+from urllib.parse import unquote
+
+from sbomify_action.logging_config import logger
+
+# Well-known in-toto predicate types.
+SLSA_PROVENANCE_V1 = "https://slsa.dev/provenance/v1"
+SPDX_DOCUMENT = "https://spdx.dev/Document"
+
+
+def extract_repo(image_ref: str) -> str:
+    """Strip ``:tag`` and ``@digest`` from an image reference.
+
+    Handles registries with ports (``localhost:5000/repo/image:tag``) by only
+    treating the last colon as a tag separator when it falls after the last
+    slash.
+    """
+    if "@" in image_ref:
+        image_ref = image_ref.split("@")[0]
+
+    last_slash = image_ref.rfind("/")
+    last_colon = image_ref.rfind(":")
+    if last_colon > last_slash:
+        image_ref = image_ref[:last_colon]
+
+    return image_ref
+
+
+def get_current_platform() -> str:
+    """Return the current platform as an OCI ``os/arch`` string."""
+    target_arch = os.environ.get("TARGETARCH")
+    if target_arch:
+        return f"linux/{target_arch}"
+
+    machine = platform.machine().lower()
+    arch_map = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+        "armv7l": "arm",
+    }
+    arch = arch_map.get(machine, machine)
+    return f"linux/{arch}"
+
+
+def crane_available() -> bool:
+    return shutil.which("crane") is not None
+
+
+def cosign_available() -> bool:
+    return shutil.which("cosign") is not None
+
+
+def _classify_registry_error(stderr: str) -> str | None:
+    """Return a human-friendly hint for common registry error shapes.
+
+    Returns ``None`` when the stderr doesn't match a known pattern — callers
+    can then log the raw message.
+    """
+    if not stderr:
+        return None
+    low = stderr.lower()
+    if "toomanyrequests" in low or "rate limit" in low or "429" in low:
+        return (
+            "Docker Hub anonymous pull rate limit exceeded (100 pulls / 6h). "
+            "Run `docker login` to raise the limit to 200/6h (free account) or "
+            "unlimited (paid)."
+        )
+    if "401" in low and "unauthorized" in low:
+        return "Registry returned 401 Unauthorized — run `docker login` to authenticate."
+    if "not found" in low or "404" in low:
+        return "Registry manifest not found (image may not exist or tag has moved)."
+    return None
+
+
+def run_crane(args: list[str]) -> str:
+    """Run a ``crane`` command and return stdout."""
+    cmd = ["crane"] + args
+    logger.debug(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=60)
+    if result.returncode != 0:
+        hint = _classify_registry_error(result.stderr)
+        if hint:
+            logger.warning(f"crane {' '.join(args)} failed: {hint}")
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
+    return result.stdout
+
+
+def run_cosign(args: list[str]) -> str:
+    """Run a ``cosign`` command and return stdout."""
+    cmd = ["cosign"] + args
+    logger.debug(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=120)
+    if result.returncode != 0:
+        hint = _classify_registry_error(result.stderr)
+        if hint:
+            logger.warning(f"cosign {' '.join(args)} failed: {hint}")
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
+    return result.stdout
+
+
+def resolve_platform_digest(image_ref: str) -> str | None:
+    """Resolve a reference to the current platform's manifest digest.
+
+    If the reference is a manifest list / OCI image index, pick the entry
+    matching the current platform. Otherwise return the single manifest's
+    digest.
+    """
+    current_platform = get_current_platform()
+    os_name, arch = current_platform.split("/")
+
+    try:
+        manifest_json = run_crane(["manifest", image_ref])
+        manifest = json.loads(manifest_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch manifest for {image_ref}: {e}")
+        return None
+
+    media_type = manifest.get("mediaType", "")
+    if "manifest.list" in media_type or "image.index" in media_type:
+        for entry in manifest.get("manifests", []):
+            p = entry.get("platform", {})
+            if p.get("os") == os_name and p.get("architecture") == arch:
+                return str(entry["digest"])
+        logger.debug(f"No matching platform {current_platform} in manifest list for {image_ref}")
+        return None
+
+    try:
+        return run_crane(["digest", image_ref]).strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def parse_purl_docker_uri(uri: str) -> tuple[str, str] | None:
+    """Parse a ``pkg:docker`` PURL into ``(image_ref, digest)``.
+
+    Example: ``pkg:docker/cgr.dev/chainguard/python?digest=sha256:abc...&platform=linux%2Famd64``
+    returns ``("cgr.dev/chainguard/python", "sha256:abc...")``.
+    """
+    if not uri.startswith("pkg:docker/"):
+        return None
+
+    rest = uri[len("pkg:docker/") :]
+    if "?" not in rest:
+        return None
+
+    path, query = rest.split("?", 1)
+    image_ref = unquote(path)
+    if "@" in image_ref:
+        image_ref = image_ref.split("@")[0]
+
+    digest = None
+    for param in query.split("&"):
+        if param.startswith("digest="):
+            digest = unquote(param[len("digest=") :])
+            break
+
+    if not digest:
+        return None
+
+    return image_ref, digest
+
+
+def parse_docker_resolved_dependency(dep: dict[str, Any]) -> tuple[str, str] | None:
+    """Parse a ``resolvedDependencies[]`` entry into ``(image_ref, digest)``.
+
+    SLSA v1 provenance may put the digest in the PURL's ``digest=`` qualifier
+    *or* in the sibling ``digest`` field on the dependency object. Docker
+    Hub's BuildKit provenance commonly uses the sibling-field form. This
+    helper handles both.
+    """
+    uri = dep.get("uri", "")
+    if not isinstance(uri, str) or not uri.startswith("pkg:docker/"):
+        return None
+
+    rest = uri[len("pkg:docker/") :]
+    path = rest.split("?", 1)[0] if "?" in rest else rest
+    image_ref = unquote(path)
+    if "@" in image_ref:
+        image_ref = image_ref.split("@")[0]
+    if not image_ref:
+        return None
+
+    if "?" in rest:
+        query = rest.split("?", 1)[1]
+        for param in query.split("&"):
+            if param.startswith("digest="):
+                return image_ref, unquote(param[len("digest=") :])
+
+    digest_field = dep.get("digest")
+    if isinstance(digest_field, dict):
+        for alg, value in digest_field.items():
+            if isinstance(alg, str) and isinstance(value, str) and alg and value:
+                return image_ref, f"{alg}:{value}"
+
+    return None
+
+
+def _find_attestation_manifest_digest(
+    index: dict[str, Any],
+    platform_digest: str | None = None,
+) -> str | None:
+    """Return the digest of the attestation-manifest sibling in an image index.
+
+    If ``platform_digest`` is given, only a sibling whose
+    ``vnd.docker.reference.digest`` matches is returned (the right choice for
+    multi-arch indexes where each platform has its own attestation sibling).
+    Otherwise the first attestation-manifest is returned — fine for callers
+    that just want to confirm provenance exists.
+    """
+    for entry in index.get("manifests", []):
+        annotations = entry.get("annotations", {})
+        if annotations.get("vnd.docker.reference.type") != "attestation-manifest":
+            continue
+        if platform_digest is None or annotations.get("vnd.docker.reference.digest") == platform_digest:
+            return str(entry["digest"])
+    return None
+
+
+def fetch_buildkit_attestation_statement(
+    image_ref: str,
+    predicate_type: str,
+    platform_digest: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch an in-toto statement attached to an image by BuildKit.
+
+    Walks the image index → attestation-manifest sibling → layer annotated with
+    the given ``predicate_type`` → parses the blob as JSON.
+
+    ``image_ref`` must resolve to an image INDEX (typically a tag like
+    ``library/python:3.11`` or an index digest like ``library/python@sha256:…``),
+    not a per-platform manifest digest. BuildKit stores attestations as siblings
+    in the index.
+
+    ``platform_digest`` is the per-platform manifest digest to match against
+    attestation siblings' ``vnd.docker.reference.digest`` annotation. Required
+    for correctness on multi-arch indexes (every platform has its own
+    attestation sibling). If omitted, the first attestation-manifest is used
+    (fine for single-arch images or when the caller just needs one provenance
+    document).
+
+    Returns the full in-toto statement (``_type``, ``predicateType``,
+    ``predicate``), or ``None`` if the image has no attestations or no layer
+    with that predicate type.
+    """
+    try:
+        index_json = run_crane(["manifest", image_ref])
+        index = json.loads(index_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch manifest for {image_ref}: {e}")
+        return None
+
+    att_digest = _find_attestation_manifest_digest(index, platform_digest=platform_digest)
+    if not att_digest:
+        if platform_digest:
+            logger.debug(f"No attestation manifest found for {image_ref} (platform digest {platform_digest})")
+        else:
+            logger.debug(f"No attestation manifest found for {image_ref}")
+        return None
+
+    registry_repo = extract_repo(image_ref)
+
+    try:
+        att_manifest_json = run_crane(["manifest", f"{registry_repo}@{att_digest}"])
+        att_manifest = json.loads(att_manifest_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch attestation manifest: {e}")
+        return None
+
+    layer_digest = None
+    for layer in att_manifest.get("layers", []):
+        annotations = layer.get("annotations", {})
+        if annotations.get("in-toto.io/predicate-type") == predicate_type:
+            layer_digest = layer["digest"]
+            break
+
+    if not layer_digest:
+        logger.debug(f"No {predicate_type} layer found in attestation for {image_ref}")
+        return None
+
+    try:
+        blob = run_crane(["blob", f"{registry_repo}@{layer_digest}"])
+        return dict(json.loads(blob))
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch attestation blob: {e}")
+        return None
+
+
+def fetch_build_provenance(image_ref: str) -> dict[str, Any] | None:
+    """Fetch the SLSA v1 provenance statement attached by BuildKit.
+
+    Does not filter by platform — provenance is usually identical across
+    platforms in a BuildKit-built image, and Chainguard's provenance parser
+    just needs to see the resolved base refs.
+    """
+    return fetch_buildkit_attestation_statement(image_ref, SLSA_PROVENANCE_V1)
+
+
+def fetch_buildkit_spdx_attestation(
+    image_ref: str,
+    platform_digest: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch the SPDX SBOM statement attached by BuildKit (OCI layer path).
+
+    Returns the SPDX document (the ``predicate`` field), not the wrapping
+    in-toto statement. Matches the shape of :func:`fetch_cosign_spdx_predicate`.
+
+    Pass ``platform_digest`` when the image is multi-arch so the
+    attestation-manifest sibling for the *current* platform is picked.
+    """
+    statement = fetch_buildkit_attestation_statement(image_ref, SPDX_DOCUMENT, platform_digest=platform_digest)
+    if statement is None:
+        return None
+    predicate = statement.get("predicate")
+    if isinstance(predicate, dict) and predicate.get("spdxVersion"):
+        return predicate
+    return None
+
+
+def iter_resolved_dependencies(statement: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield ``resolvedDependencies`` entries from a SLSA v1 provenance statement."""
+    resolved = statement.get("predicate", {}).get("buildDefinition", {}).get("resolvedDependencies", [])
+    yield from resolved
+
+
+def fetch_cosign_spdx_predicate(
+    image_with_digest: str,
+    extra_cosign_args: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Run ``cosign download attestation`` and extract the SPDX predicate.
+
+    ``cosign`` emits one JSON DSSE envelope per line. Each envelope has a
+    base64-encoded ``payload`` that is the in-toto statement. We scan for a
+    statement whose ``predicateType`` is ``https://spdx.dev/Document`` and
+    return its ``predicate`` (the SPDX document itself).
+
+    ``extra_cosign_args`` are inserted before the image reference; use this
+    to pass keys / tlog flags for signed-but-not-Rekor-logged attestations
+    (e.g., Docker Hardened Images).
+    """
+    args = ["download", "attestation"]
+    if extra_cosign_args:
+        args.extend(extra_cosign_args)
+    args.append(image_with_digest)
+
+    try:
+        output = run_cosign(args)
+    except subprocess.CalledProcessError as e:
+        logger.debug(f"cosign download attestation failed for {image_with_digest}: {e.stderr or e}")
+        return None
+
+    for line in output.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            envelope = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        payload_b64 = envelope.get("payload", "")
+        if not payload_b64:
+            continue
+
+        try:
+            payload = json.loads(base64.b64decode(payload_b64))
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, binascii.Error):
+            continue
+
+        if payload.get("predicateType") != SPDX_DOCUMENT:
+            continue
+
+        predicate = payload.get("predicate")
+        if isinstance(predicate, dict) and predicate.get("spdxVersion"):
+            return dict(predicate)
+
+    return None

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -4,17 +4,11 @@ Detects Chainguard images (direct or as base images in user-built images),
 downloads their SPDX SBOMs from cosign attestations, and converts to CycloneDX.
 """
 
-import base64
-import binascii
 import json
-import os
-import platform
-import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
-from urllib.parse import unquote
 
 from cyclonedx.model import HashAlgorithm, HashType
 from cyclonedx.model.bom import Bom
@@ -26,6 +20,14 @@ from packageurl import PackageURL
 from sbomify_action.logging_config import logger
 from sbomify_action.serialization import serialize_cyclonedx_bom
 
+from . import buildkit_provenance as bkp
+
+# Re-export internals referenced by tests. Keep these as thin aliases so test
+# imports (``from sbomify_action._generation.chainguard import _extract_repo``)
+# continue to resolve after the shared-helper extraction.
+_extract_repo = bkp.extract_repo
+_parse_purl_docker_uri = bkp.parse_purl_docker_uri
+
 
 @dataclass
 class ChainguardBaseImage:
@@ -35,108 +37,18 @@ class ChainguardBaseImage:
     digest: str  # per-architecture digest, e.g., "sha256:242e08c..."
 
 
-def _extract_repo(image_ref: str) -> str:
-    """Extract the repository (without tag or digest) from an image reference.
-
-    Handles registries with ports (e.g., localhost:5000/repo/image:tag)
-    by only stripping a :tag suffix when the colon appears after the last /.
-    """
-    # Strip @digest first
-    if "@" in image_ref:
-        image_ref = image_ref.split("@")[0]
-
-    # Strip :tag only if the colon is after the last /
-    last_slash = image_ref.rfind("/")
-    last_colon = image_ref.rfind(":")
-    if last_colon > last_slash:
-        image_ref = image_ref[:last_colon]
-
-    return image_ref
-
-
-def _get_current_platform() -> str:
-    """Get the current platform in OCI format (e.g., 'linux/amd64')."""
-    # Check environment variable first (CI environments may set this)
-    target_arch = os.environ.get("TARGETARCH")
-    if target_arch:
-        return f"linux/{target_arch}"
-
-    machine = platform.machine().lower()
-    arch_map = {
-        "x86_64": "amd64",
-        "amd64": "amd64",
-        "aarch64": "arm64",
-        "arm64": "arm64",
-        "armv7l": "arm",
-    }
-    arch = arch_map.get(machine, machine)
-    return f"linux/{arch}"
-
-
-def _run_crane(args: list[str]) -> str:
-    """Run a crane command and return stdout."""
-    cmd = ["crane"] + args
-    logger.debug(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
-    return result.stdout
-
-
-def _run_cosign(args: list[str]) -> str:
-    """Run a cosign command and return stdout."""
-    cmd = ["cosign"] + args
-    logger.debug(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
-    return result.stdout
-
-
-def _resolve_platform_digest(image_ref: str) -> str | None:
-    """Resolve an image reference to a platform-specific manifest digest.
-
-    If the image is a manifest list (multi-arch), resolves to the current platform.
-    If it's already a single manifest, returns its digest.
-    """
-    current_platform = _get_current_platform()
-    os_name, arch = current_platform.split("/")
-
-    try:
-        manifest_json = _run_crane(["manifest", image_ref])
-        manifest = json.loads(manifest_json)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-        logger.debug(f"Failed to fetch manifest for {image_ref}: {e}")
-        return None
-
-    # Check if this is a manifest list / OCI image index
-    media_type = manifest.get("mediaType", "")
-    if "manifest.list" in media_type or "image.index" in media_type:
-        for entry in manifest.get("manifests", []):
-            p = entry.get("platform", {})
-            if p.get("os") == os_name and p.get("architecture") == arch:
-                return str(entry["digest"])
-        logger.debug(f"No matching platform {current_platform} in manifest list for {image_ref}")
-        return None
-
-    # Single manifest — get its digest
-    try:
-        digest = _run_crane(["digest", image_ref]).strip()
-        return digest
-    except subprocess.CalledProcessError:
-        return None
-
-
 def _is_chainguard_config(image_ref: str) -> bool:
     """Check if an image config indicates a Chainguard image."""
     try:
-        config_json = _run_crane(["config", image_ref])
+        config_json = bkp.run_crane(["config", image_ref])
         config = json.loads(config_json)
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
         logger.debug(f"Failed to fetch config for {image_ref}: {e}")
         return False
 
-    # Check author field (set by apko)
     if config.get("author") == "github.com/chainguard-dev/apko":
         return True
 
-    # Check labels
     labels = config.get("config", {}).get("Labels", {})
     if "dev.chainguard.image.title" in labels:
         return True
@@ -155,123 +67,33 @@ def _detect_direct_chainguard(docker_image: str) -> ChainguardBaseImage | None:
         logger.debug(f"Image config does not match Chainguard pattern: {docker_image}")
         return None
 
-    digest = _resolve_platform_digest(docker_image)
+    digest = bkp.resolve_platform_digest(docker_image)
     if not digest:
         logger.warning(f"Could not resolve platform digest for {docker_image}")
         return None
 
-    # Extract the image ref without tag/digest for the ChainguardBaseImage
-    image_ref = _extract_repo(docker_image)
-    return ChainguardBaseImage(image_ref=image_ref, digest=digest)
-
-
-def _parse_purl_docker_uri(uri: str) -> tuple[str, str] | None:
-    """Parse a pkg:docker URI into (image_ref, digest).
-
-    Example: pkg:docker/cgr.dev/chainguard/python?digest=sha256:abc...&platform=linux%2Famd64
-    Returns: ("cgr.dev/chainguard/python", "sha256:abc...")
-    """
-    if not uri.startswith("pkg:docker/"):
-        return None
-
-    # Remove pkg:docker/ prefix
-    rest = uri[len("pkg:docker/") :]
-
-    # Split on ? to separate path from query
-    if "?" in rest:
-        path, query = rest.split("?", 1)
-    else:
-        return None
-
-    # Decode the path
-    image_ref = unquote(path)
-    # Remove @tag if present (e.g., pkg:docker/alpine@3.21)
-    if "@" in image_ref:
-        image_ref = image_ref.split("@")[0]
-
-    # Parse query parameters for digest
-    digest = None
-    for param in query.split("&"):
-        if param.startswith("digest="):
-            digest = unquote(param[len("digest=") :])
-            break
-
-    if not digest:
-        return None
-
-    return image_ref, digest
+    return ChainguardBaseImage(image_ref=bkp.extract_repo(docker_image), digest=digest)
 
 
 def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage | None:
-    """Detect Chainguard base image by parsing BuildKit provenance attestation."""
-    try:
-        index_json = _run_crane(["manifest", docker_image])
-        index = json.loads(index_json)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-        logger.debug(f"Failed to fetch manifest for {docker_image}: {e}")
+    """Detect Chainguard base image by parsing BuildKit SLSA provenance."""
+    statement = bkp.fetch_build_provenance(docker_image)
+    if statement is None:
         return None
 
-    # Find attestation manifest in the image index
-    att_digest = None
-    for entry in index.get("manifests", []):
-        annotations = entry.get("annotations", {})
-        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
-            att_digest = entry["digest"]
-            break
-
-    if not att_digest:
-        logger.debug(f"No attestation manifest found for {docker_image}")
-        return None
-
-    # Fetch the attestation manifest to find the provenance layer
-    try:
-        registry_repo = _extract_repo(docker_image)
-        att_manifest_json = _run_crane(["manifest", f"{registry_repo}@{att_digest}"])
-        att_manifest = json.loads(att_manifest_json)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-        logger.debug(f"Failed to fetch attestation manifest: {e}")
-        return None
-
-    # Find SLSA provenance layer
-    provenance_digest = None
-    for layer in att_manifest.get("layers", []):
-        annotations = layer.get("annotations", {})
-        if annotations.get("in-toto.io/predicate-type") == "https://slsa.dev/provenance/v1":
-            provenance_digest = layer["digest"]
-            break
-
-    if not provenance_digest:
-        logger.debug(f"No SLSA provenance layer found in attestation for {docker_image}")
-        return None
-
-    # Fetch and parse the provenance blob
-    try:
-        provenance_json = _run_crane(["blob", f"{registry_repo}@{provenance_digest}"])
-        provenance = json.loads(provenance_json)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-        logger.debug(f"Failed to fetch provenance blob: {e}")
-        return None
-
-    # Search resolvedDependencies for Chainguard images
-    resolved_deps = provenance.get("predicate", {}).get("buildDefinition", {}).get("resolvedDependencies", [])
-
-    for dep in resolved_deps:
+    for dep in bkp.iter_resolved_dependencies(statement):
         uri = dep.get("uri", "")
         if "cgr.dev/chainguard/" not in uri:
             continue
 
-        parsed = _parse_purl_docker_uri(uri)
+        parsed = bkp.parse_purl_docker_uri(uri)
         if not parsed:
             continue
 
         image_ref, digest = parsed
         logger.info(f"Found Chainguard base image in provenance: {image_ref}@{digest}")
 
-        # Resolve to per-architecture digest if this is an index digest
-        platform_digest = _resolve_platform_digest(f"{image_ref}@{digest}")
-        if not platform_digest:
-            platform_digest = digest
-
+        platform_digest = bkp.resolve_platform_digest(f"{image_ref}@{digest}") or digest
         return ChainguardBaseImage(image_ref=image_ref, digest=platform_digest)
 
     logger.debug(f"No Chainguard base image found in provenance for {docker_image}")
@@ -288,70 +110,32 @@ def detect_chainguard_image(docker_image: str) -> ChainguardBaseImage | None:
     Returns ChainguardBaseImage with the per-architecture digest, or None if not detected.
     Requires crane to be available on PATH.
     """
-    if not shutil.which("crane"):
+    if not bkp.crane_available():
         logger.debug("crane not found on PATH, skipping Chainguard detection")
         return None
 
-    # Path A: Direct Chainguard image
     result = _detect_direct_chainguard(docker_image)
     if result:
         return result
 
-    # Path B: User-built image FROM Chainguard
     return _detect_chainguard_from_provenance(docker_image)
 
 
 def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict[str, Any]:
-    """Download the SPDX SBOM from a Chainguard image's cosign attestation.
-
-    Args:
-        info: Detected Chainguard image info with per-architecture digest
-
-    Returns:
-        SPDX document as a dict
-
-    Raises:
-        RuntimeError: If SBOM cannot be fetched or parsed
-    """
-    if not shutil.which("cosign"):
+    """Download the SPDX SBOM from a Chainguard image's cosign attestation."""
+    if not bkp.cosign_available():
         raise RuntimeError("cosign not found on PATH, cannot fetch Chainguard SBOM")
 
     image_with_digest = f"{info.image_ref}@{info.digest}"
     logger.info(f"Fetching Chainguard SBOM for {image_with_digest}")
 
-    try:
-        output = _run_cosign(["download", "attestation", image_with_digest])
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to download attestation for {image_with_digest}: {e.stderr or e}") from e
+    predicate = bkp.fetch_cosign_spdx_predicate(image_with_digest)
+    if predicate is None:
+        raise RuntimeError(f"No SPDX SBOM found in attestations for {image_with_digest}")
 
-    # Parse each line as a JSON attestation envelope
-    for line in output.strip().split("\n"):
-        line = line.strip()
-        if not line:
-            continue
-
-        try:
-            envelope = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        payload_b64 = envelope.get("payload", "")
-        if not payload_b64:
-            continue
-
-        try:
-            payload = json.loads(base64.b64decode(payload_b64))
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, binascii.Error):
-            continue
-
-        if payload.get("predicateType") == "https://spdx.dev/Document":
-            predicate = payload.get("predicate", {})
-            if predicate.get("spdxVersion"):
-                pkg_count = len(predicate.get("packages", []))
-                logger.info(f"Found Chainguard SPDX SBOM with {pkg_count} packages")
-                return dict(predicate)
-
-    raise RuntimeError(f"No SPDX SBOM found in attestations for {image_with_digest}")
+    pkg_count = len(predicate.get("packages", []))
+    logger.info(f"Found Chainguard SPDX SBOM with {pkg_count} packages")
+    return predicate
 
 
 # CycloneDX hash algorithm mapping from SPDX algorithm names
@@ -365,13 +149,13 @@ _SPDX_TO_CDX_HASH_ALG: dict[str, HashAlgorithm] = {
 
 
 def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6") -> str:
-    """Convert a Chainguard SPDX SBOM to CycloneDX JSON.
+    """Convert an SPDX 2.x SBOM dict to CycloneDX JSON.
 
-    Handles the simple structure of Chainguard SBOMs: packages with PURLs,
-    checksums, and supplier info.
+    Handles the simple package shape (PURLs, checksums, supplier, description).
+    Generic enough to use on any SPDX 2.x doc (Chainguard, Docker Hub, etc.).
 
     Args:
-        spdx_doc: SPDX document dict (from fetch_chainguard_sbom)
+        spdx_doc: SPDX document dict
         spec_version: Target CycloneDX spec version (default "1.6")
 
     Returns:
@@ -379,7 +163,6 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
     """
     bom = Bom()
 
-    # Set metadata
     creation_info = spdx_doc.get("creationInfo", {})
     created = creation_info.get("created")
     if created:
@@ -388,16 +171,13 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
         except ValueError:
             pass
 
-    # Add tool info from SPDX creators
     for creator in creation_info.get("creators", []):
         if creator.startswith("Tool:"):
             tool_name = creator[len("Tool:") :].strip()
             bom.metadata.tools.tools.add(Tool(name=tool_name))
 
-    # Track which SPDX IDs are "described" (top-level components)
     described_ids = set(spdx_doc.get("documentDescribes", []))
 
-    # Build components from SPDX packages
     components: list[Component] = []
     main_component: Component | None = None
 
@@ -406,14 +186,12 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
         name = pkg.get("name", "")
         version = pkg.get("versionInfo", "")
 
-        # Extract PURL from external refs
         purl_str = None
         for ref in pkg.get("externalRefs", []):
             if ref.get("referenceType") == "purl":
                 purl_str = ref.get("referenceLocator", "")
                 break
 
-        # Determine component type
         purpose = pkg.get("primaryPackagePurpose", "")
         if purpose == "CONTAINER":
             comp_type = ComponentType.CONTAINER
@@ -422,7 +200,6 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
         else:
             comp_type = ComponentType.LIBRARY
 
-        # Build component
         comp = Component(
             type=comp_type,
             name=name,
@@ -436,15 +213,12 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
             except ValueError:
                 pass
 
-        # Add supplier
         supplier_str = pkg.get("supplier", "")
         if supplier_str and supplier_str != "NOASSERTION":
-            # Parse "Organization: Chainguard, Inc." format
             if supplier_str.startswith("Organization:"):
                 org_name = supplier_str[len("Organization:") :].strip()
                 comp.supplier = OrganizationalEntity(name=org_name)
 
-        # Add hashes
         for checksum in pkg.get("checksums", []):
             alg = checksum.get("algorithm", "")
             value = checksum.get("checksumValue", "")
@@ -452,24 +226,19 @@ def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6
             if cdx_alg and value:
                 comp.hashes.add(HashType(alg=cdx_alg, content=value))
 
-        # Add description
         description = pkg.get("description", "")
         if description:
             comp.description = description
 
-        # Set as main component if it's the described package
         if spdx_id in described_ids and main_component is None:
             main_component = comp
         else:
             components.append(comp)
 
-    # Set main component in metadata
     if main_component:
         bom.metadata.component = main_component
 
-    # Add all other components
     for comp in components:
         bom.components.add(comp)
 
-    # Serialize
     return serialize_cyclonedx_bom(bom, spec_version)

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -151,15 +151,20 @@ _SPDX_TO_CDX_HASH_ALG: dict[str, HashAlgorithm] = {
 def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6") -> str:
     """Convert an SPDX 2.x SBOM dict to CycloneDX JSON.
 
-    Handles the simple package shape (PURLs, checksums, supplier, description).
-    Generic enough to use on any SPDX 2.x doc (Chainguard, Docker Hub, etc.).
+    Generic SPDX 2.x → CDX 1.x converter (not Chainguard-specific despite its
+    module location). Reads the package shape only (PURLs, checksums, supplier,
+    description, license); SPDX files and file-level relationships are
+    intentionally not carried over — the resulting CDX describes packages, not
+    individual filesystem entries. Also used by the Docker Hub merge path
+    (:mod:`.sbom_merge`).
 
     Args:
-        spdx_doc: SPDX document dict
-        spec_version: Target CycloneDX spec version (default "1.6")
+        spdx_doc: SPDX document dict (the ``predicate`` body from an in-toto
+            attestation, not the wrapping statement).
+        spec_version: Target CycloneDX spec version (default "1.6").
 
     Returns:
-        CycloneDX JSON string
+        CycloneDX JSON string.
     """
     bom = Bom()
 

--- a/sbomify_action/_generation/dockerhub.py
+++ b/sbomify_action/_generation/dockerhub.py
@@ -26,11 +26,13 @@ SBOM delivery differs by tier:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from sbomify_action.logging_config import logger
 
 from . import buildkit_provenance as bkp
+
+DockerHubTier = Literal["official", "dhi"]
 
 DHI_COSIGN_KEY_URL = "https://registry.scout.docker.com/keyring/dhi/latest.pub"
 _DOCKER_HUB_HOSTS = {"docker.io", "index.docker.io", "registry-1.docker.io"}
@@ -64,10 +66,10 @@ class DockerHubBaseImage:
     image_ref: str  # canonical repo, e.g., "docker.io/library/python"
     index_ref: str  # ref that resolves to an image index
     digest: str  # per-platform manifest digest
-    tier: str  # "official" or "dhi"
+    tier: DockerHubTier
 
 
-def _classify_ref(image_ref: str) -> str | None:
+def _classify_ref(image_ref: str) -> DockerHubTier | None:
     """Return ``"official"``, ``"dhi"``, or ``None`` for an image reference.
 
     Handles both full refs (``docker.io/library/python``) and the shorthand
@@ -103,7 +105,7 @@ def _classify_ref(image_ref: str) -> str | None:
     return None
 
 
-def _canonicalize(image_ref: str, tier: str) -> str:
+def _canonicalize(image_ref: str, tier: DockerHubTier) -> str:
     """Return the canonical ``registry/namespace/name`` form for display/logs."""
     base = bkp.extract_repo(image_ref)
     if tier == "dhi":
@@ -209,10 +211,16 @@ def fetch_dockerhub_sbom(info: DockerHubBaseImage) -> dict[str, Any] | None:
         if not bkp.cosign_available():
             logger.warning("cosign not found on PATH, cannot fetch DHI SBOM")
             return None
-        # DHI attestations are keyed on the platform manifest digest.
+        # DHI attestations are keyed on the platform manifest digest and
+        # cosign-signed with Docker's scout keyring. verify=True runs
+        # `cosign verify-attestation` so the signature is actually checked
+        # against Docker's published key — download-only would silently
+        # accept tampered attestations. DHI isn't logged to public Rekor,
+        # so the tlog check is explicitly skipped.
         predicate = bkp.fetch_cosign_spdx_predicate(
             f"{info.image_ref}@{info.digest}",
             extra_cosign_args=["--key", DHI_COSIGN_KEY_URL, "--insecure-ignore-tlog=true"],
+            verify=True,
         )
     else:
         # Official Images attach SBOM attestations as siblings in the image

--- a/sbomify_action/_generation/dockerhub.py
+++ b/sbomify_action/_generation/dockerhub.py
@@ -1,0 +1,229 @@
+"""Docker Hub base image detection and upstream SBOM fetch.
+
+Two detection paths mirror :mod:`chainguard`:
+
+1. **Direct** — ``docker_image`` itself is a Docker Official Image
+   (``docker.io/library/*`` or the implicit-library shorthand) or a Docker
+   Hardened Image (``dhi.io/*``).
+2. **Provenance** — ``docker_image`` was built with BuildKit and its SLSA v1
+   provenance lists a Docker Hub base image under ``resolvedDependencies``.
+
+Unlike Chainguard, Docker Hub images are commonly *extended* by users
+(``FROM python:3.11 && RUN apt-get install ...``). The CLI integration pairs
+this upstream SBOM with a local Syft scan and merges them via
+:mod:`sbom_merge`.
+
+SBOM delivery differs by tier:
+
+* **Docker Official Images** attach an unsigned SPDX in-toto attestation
+  alongside the image manifest (``vnd.docker.reference.type=attestation-manifest``
+  sibling in the OCI index). Fetched with crane.
+* **Docker Hardened Images (DHI)** ship cosign-signed attestations keyed
+  against Docker's scout keyring, with Rekor transparency logging skipped.
+  Fetched with ``cosign download attestation --key ... --insecure-ignore-tlog=true``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sbomify_action.logging_config import logger
+
+from . import buildkit_provenance as bkp
+
+DHI_COSIGN_KEY_URL = "https://registry.scout.docker.com/keyring/dhi/latest.pub"
+_DOCKER_HUB_HOSTS = {"docker.io", "index.docker.io", "registry-1.docker.io"}
+_DHI_HOST = "dhi.io"
+
+# User-facing warning shown when Docker Hub SBOMs are consumed. Kept short
+# enough for the GitHub Actions job-summary warning box.
+DOCKERHUB_MERGE_WARNING = (
+    "Using Docker Hub's upstream SBOM merged with a local Syft scan. Docker's "
+    "published attestation is authoritative for base-layer packages; Syft "
+    "overlays packages your Dockerfile added on top (apt, pip, COPY/ADD, etc). "
+    "Some gaps can remain — for the fullest coverage, build your image with "
+    "`docker buildx --sbom=true --provenance=true` so BuildKit attaches a "
+    "complete SBOM directly. See: "
+    "https://github.com/sbomify/sbomify-action#docker-hub-images"
+)
+
+
+@dataclass
+class DockerHubBaseImage:
+    """Information about a detected Docker Hub base image.
+
+    ``index_ref`` is the ref that resolves to the *image index* (typically a
+    tag like ``docker.io/library/python:3.11`` or ``<repo>@<index-digest>``),
+    which is where BuildKit parks the attestation-manifest siblings.
+    ``digest`` is the per-platform manifest digest, used both to match the
+    correct attestation sibling in multi-arch indexes and to key cosign
+    lookups for DHI.
+    """
+
+    image_ref: str  # canonical repo, e.g., "docker.io/library/python"
+    index_ref: str  # ref that resolves to an image index
+    digest: str  # per-platform manifest digest
+    tier: str  # "official" or "dhi"
+
+
+def _classify_ref(image_ref: str) -> str | None:
+    """Return ``"official"``, ``"dhi"``, or ``None`` for an image reference.
+
+    Handles both full refs (``docker.io/library/python``) and the shorthand
+    forms Docker CLI accepts (``library/nginx``, bare ``python``).
+    """
+    base = bkp.extract_repo(image_ref)
+    if not base:
+        return None
+
+    if base == _DHI_HOST or base.startswith(f"{_DHI_HOST}/"):
+        return "dhi"
+
+    parts = base.split("/")
+    first = parts[0]
+    # Docker's own heuristic: a segment is a registry host iff it has a dot,
+    # a colon (port), or is "localhost".
+    has_registry = "." in first or ":" in first or first == "localhost"
+
+    if has_registry:
+        if first in _DOCKER_HUB_HOSTS:
+            if len(parts) == 3 and parts[1] == "library":
+                return "official"
+            return None
+        return None
+
+    # Implicit docker.io registry.
+    if len(parts) == 1:
+        # Bare name: docker.io/library/<name>
+        return "official"
+    if len(parts) == 2 and parts[0] == "library":
+        return "official"
+    # docker.io/<user>/<repo> — not an Official Image.
+    return None
+
+
+def _canonicalize(image_ref: str, tier: str) -> str:
+    """Return the canonical ``registry/namespace/name`` form for display/logs."""
+    base = bkp.extract_repo(image_ref)
+    if tier == "dhi":
+        if not base.startswith(f"{_DHI_HOST}/") and base != _DHI_HOST:
+            return f"{_DHI_HOST}/{base}"
+        return base
+    # Official: ensure docker.io/library/<name>
+    parts = base.split("/")
+    first = parts[0]
+    has_registry = "." in first or ":" in first or first == "localhost"
+    if has_registry:
+        if first in _DOCKER_HUB_HOSTS:
+            return "docker.io/" + "/".join(parts[1:])
+        return base
+    if len(parts) == 1:
+        return f"docker.io/library/{parts[0]}"
+    if parts[0] == "library":
+        return f"docker.io/{base}"
+    return base
+
+
+def _detect_direct(docker_image: str) -> DockerHubBaseImage | None:
+    tier = _classify_ref(docker_image)
+    if tier is None:
+        return None
+
+    logger.debug(f"Image ref matches Docker Hub {tier} pattern, verifying: {docker_image}")
+
+    digest = bkp.resolve_platform_digest(docker_image)
+    if not digest:
+        logger.debug(f"Could not resolve platform digest for {docker_image}")
+        return None
+
+    # The user-provided ref typically resolves to the image INDEX (tags do),
+    # which is where BuildKit stores attestation-manifest siblings.
+    return DockerHubBaseImage(
+        image_ref=_canonicalize(docker_image, tier),
+        index_ref=docker_image,
+        digest=digest,
+        tier=tier,
+    )
+
+
+def _detect_from_provenance(docker_image: str) -> DockerHubBaseImage | None:
+    statement = bkp.fetch_build_provenance(docker_image)
+    if statement is None:
+        return None
+
+    for dep in bkp.iter_resolved_dependencies(statement):
+        parsed = bkp.parse_docker_resolved_dependency(dep)
+        if not parsed:
+            continue
+
+        base_ref, base_digest = parsed
+        tier = _classify_ref(base_ref)
+        if tier is None:
+            continue
+
+        logger.info(f"Found Docker Hub base image in provenance: {base_ref}@{base_digest}")
+        # BuildKit's resolvedDependencies digest is typically the image-INDEX
+        # digest (what `FROM python:3.11` saw), so `base_ref@base_digest` is a
+        # valid index ref. Resolve down to the per-platform manifest for
+        # attestation sibling matching.
+        index_ref = f"{base_ref}@{base_digest}"
+        platform_digest = bkp.resolve_platform_digest(index_ref) or base_digest
+        return DockerHubBaseImage(
+            image_ref=_canonicalize(base_ref, tier),
+            index_ref=index_ref,
+            digest=platform_digest,
+            tier=tier,
+        )
+
+    logger.debug(f"No Docker Hub base image found in provenance for {docker_image}")
+    return None
+
+
+def detect_dockerhub_image(docker_image: str) -> DockerHubBaseImage | None:
+    """Detect whether ``docker_image`` is or is built FROM a Docker Hub image.
+
+    Returns ``None`` if not detected or if crane is unavailable.
+    """
+    if not bkp.crane_available():
+        logger.debug("crane not found on PATH, skipping Docker Hub detection")
+        return None
+
+    direct = _detect_direct(docker_image)
+    if direct:
+        return direct
+
+    return _detect_from_provenance(docker_image)
+
+
+def fetch_dockerhub_sbom(info: DockerHubBaseImage) -> dict[str, Any] | None:
+    """Fetch the upstream SPDX SBOM for a detected Docker Hub image.
+
+    Returns the SPDX document (the ``predicate`` body) or ``None`` if no
+    SBOM attestation is attached. Some older Official Images don't ship
+    attestations — callers should fall through to a plain Syft scan.
+    """
+    logger.info(f"Fetching Docker Hub upstream SBOM for {info.image_ref}@{info.digest} (tier={info.tier})")
+
+    if info.tier == "dhi":
+        if not bkp.cosign_available():
+            logger.warning("cosign not found on PATH, cannot fetch DHI SBOM")
+            return None
+        # DHI attestations are keyed on the platform manifest digest.
+        predicate = bkp.fetch_cosign_spdx_predicate(
+            f"{info.image_ref}@{info.digest}",
+            extra_cosign_args=["--key", DHI_COSIGN_KEY_URL, "--insecure-ignore-tlog=true"],
+        )
+    else:
+        # Official Images attach SBOM attestations as siblings in the image
+        # INDEX. Pull the index via index_ref and match the sibling whose
+        # vnd.docker.reference.digest equals our platform digest.
+        predicate = bkp.fetch_buildkit_spdx_attestation(info.index_ref, platform_digest=info.digest)
+
+    if predicate is None:
+        logger.info(f"No upstream SBOM attestation found for {info.image_ref}@{info.digest}")
+        return None
+
+    pkg_count = len(predicate.get("packages", []))
+    logger.info(f"Fetched upstream SBOM with {pkg_count} packages for {info.image_ref}")
+    return predicate

--- a/sbomify_action/_generation/sbom_merge.py
+++ b/sbomify_action/_generation/sbom_merge.py
@@ -111,11 +111,17 @@ def _cdx_fill_empty(upstream: dict[str, Any], syft: dict[str, Any]) -> None:
         if not upstream.get(field) and syft.get(field):
             upstream[field] = syft[field]
 
-    existing_urls = {r.get("url") for r in upstream.get("externalReferences", [])}
+    # Key by (type, url): CycloneDX lets the same URL appear with different
+    # types (e.g., "vcs" and "website"), and those are semantically distinct.
+    existing_refs = {(r.get("type"), r.get("url")) for r in upstream.get("externalReferences", [])}
     for ref in syft.get("externalReferences", []):
-        if ref.get("url") and ref.get("url") not in existing_urls:
+        url = ref.get("url")
+        if not url:
+            continue
+        key = (ref.get("type"), url)
+        if key not in existing_refs:
             upstream.setdefault("externalReferences", []).append(ref)
-            existing_urls.add(ref.get("url"))
+            existing_refs.add(key)
 
 
 def _collect_cdx_bom_refs(bom: dict[str, Any]) -> set[str]:

--- a/sbomify_action/_generation/sbom_merge.py
+++ b/sbomify_action/_generation/sbom_merge.py
@@ -1,0 +1,384 @@
+"""Merge an authoritative upstream SBOM with a local Syft scan.
+
+Used when consuming Docker Hub upstream SBOMs: the publisher's signed SBOM is
+authoritative for base-image packages, but Syft is needed to catch anything
+the user's Dockerfile added on top (``pip install``, ``apt-get install``, etc.).
+
+Merge policy (confirmed with user):
+
+* **Upstream wins on conflict.** Upstream component metadata is never
+  overwritten by Syft.
+* **Syft fills gaps.** For a PURL present in both, any *empty* upstream field
+  (description, licenses, supplier, hashes, ...) is filled from Syft.
+* **Syft adds overlay.** For a PURL only in Syft's scan, the component is
+  appended to upstream and tagged ``sbomify:source=syft-overlay``.
+* Upstream components are tagged ``sbomify:source=docker-hub-upstream``.
+
+Works on parsed JSON dicts rather than ``cyclonedx-python-lib`` /
+``spdx-tools`` objects — simpler and avoids round-trip serialization cost.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from packageurl import PackageURL
+
+SBOMIFY_SOURCE_PROP = "sbomify:source"
+SOURCE_DOCKERHUB = "docker-hub-upstream"
+SOURCE_SYFT = "syft-overlay"
+
+
+def _purl_identity(purl_str: str | None) -> tuple[str, str, str, str] | None:
+    """Return a PURL's core identity (type, namespace, name, version).
+
+    Qualifiers are intentionally ignored so that the same package emitted by
+    different generators matches — e.g., Docker's BuildKit SBOM emits
+    ``pkg:deb/debian/acl@2.3.2?os_distro=trixie&os_name=debian`` while Syft
+    emits ``pkg:deb/debian/acl@2.3.2?arch=amd64&distro=debian-13``. They're
+    the same package; dedup should collapse them.
+
+    Returns ``None`` if the PURL is missing, malformed, or lacks a version
+    (falling back to string-equality dedup would over-merge in that case).
+    """
+    if not purl_str:
+        return None
+    try:
+        parsed = PackageURL.from_string(purl_str)
+    except ValueError:
+        return None
+    if not parsed.type or not parsed.name or not parsed.version:
+        return None
+    return (parsed.type, parsed.namespace or "", parsed.name, parsed.version)
+
+
+def _purl_identity_loose(purl_str: str | None) -> tuple[str, str, str] | None:
+    """Return a looser PURL identity (type, name, version), dropping namespace.
+
+    Used as a second-pass fallback when the strict identity doesn't match.
+    Needed because some generators disagree on the ``namespace`` portion of OS
+    package PURLs — e.g., Amazon Linux's upstream SBOM uses
+    ``pkg:rpm/amazonlinux/bash`` while Syft emits ``pkg:rpm/amzn/bash``.
+
+    Safe because the merge runs over *one image at a time*: upstream and Syft
+    are describing the same artifact, so two components with the same type,
+    name, and version in different namespaces are overwhelmingly the same
+    package rather than a collision across distros.
+    """
+    if not purl_str:
+        return None
+    try:
+        parsed = PackageURL.from_string(purl_str)
+    except ValueError:
+        return None
+    if not parsed.type or not parsed.name or not parsed.version:
+        return None
+    return (parsed.type, parsed.name, parsed.version)
+
+
+# ---------------------------------------------------------------------------
+# CycloneDX merge
+# ---------------------------------------------------------------------------
+
+
+def _cdx_purl(comp: dict[str, Any]) -> str | None:
+    purl = comp.get("purl")
+    return purl if purl else None
+
+
+def _cdx_identity(comp: dict[str, Any]) -> tuple[str, str, str, str] | None:
+    return _purl_identity(_cdx_purl(comp))
+
+
+def _cdx_identity_loose(comp: dict[str, Any]) -> tuple[str, str, str] | None:
+    return _purl_identity_loose(_cdx_purl(comp))
+
+
+def _cdx_set_source(comp: dict[str, Any], source: str) -> None:
+    """Set the ``sbomify:source`` property on a CycloneDX component."""
+    props = [p for p in comp.get("properties", []) if p.get("name") != SBOMIFY_SOURCE_PROP]
+    props.append({"name": SBOMIFY_SOURCE_PROP, "value": source})
+    comp["properties"] = props
+
+
+def _cdx_fill_empty(upstream: dict[str, Any], syft: dict[str, Any]) -> None:
+    """Copy Syft fields into upstream only where upstream is empty/missing."""
+    for field in ("description", "author", "publisher", "cpe", "group"):
+        if not upstream.get(field) and syft.get(field):
+            upstream[field] = syft[field]
+
+    for field in ("supplier", "licenses", "hashes"):
+        if not upstream.get(field) and syft.get(field):
+            upstream[field] = syft[field]
+
+    existing_urls = {r.get("url") for r in upstream.get("externalReferences", [])}
+    for ref in syft.get("externalReferences", []):
+        if ref.get("url") and ref.get("url") not in existing_urls:
+            upstream.setdefault("externalReferences", []).append(ref)
+            existing_urls.add(ref.get("url"))
+
+
+def _collect_cdx_bom_refs(bom: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    meta_ref = bom.get("metadata", {}).get("component", {}).get("bom-ref")
+    if meta_ref:
+        refs.add(meta_ref)
+    for c in bom.get("components", []):
+        ref = c.get("bom-ref")
+        if ref:
+            refs.add(ref)
+    return refs
+
+
+def _unique_bom_ref(candidate: str, taken: set[str]) -> str:
+    if candidate not in taken:
+        return candidate
+    n = 1
+    while True:
+        new = f"{candidate}-syft-{n}"
+        if new not in taken:
+            return new
+        n += 1
+
+
+def merge_cyclonedx(upstream: dict[str, Any], syft: dict[str, Any]) -> dict[str, Any]:
+    """Merge ``syft`` (CycloneDX dict) into ``upstream`` (CycloneDX dict).
+
+    Mutates and returns ``upstream``. Upstream wins on conflict; Syft-only
+    components are appended with the ``syft-overlay`` source tag.
+
+    Dedup is two-pass:
+
+    1. **Strict** — match on ``(type, namespace, name, version)``, ignoring
+       qualifiers. Handles different qualifier conventions across generators.
+    2. **Loose fallback** — match on ``(type, name, version)``, ignoring
+       namespace. Handles cases where upstream and Syft disagree on the
+       namespace portion (e.g., upstream ``pkg:rpm/amazonlinux/bash`` vs
+       Syft ``pkg:rpm/amzn/bash``).
+    """
+    components = upstream.setdefault("components", [])
+
+    by_identity: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    by_loose: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for comp in components:
+        _cdx_set_source(comp, SOURCE_DOCKERHUB)
+        identity = _cdx_identity(comp)
+        if identity is not None:
+            by_identity[identity] = comp
+        loose = _cdx_identity_loose(comp)
+        if loose is not None:
+            # First upstream component with this loose key wins the index
+            # slot (upstream's ordering is preserved, so this gives us
+            # deterministic behavior if upstream has multiple entries
+            # sharing a loose key).
+            by_loose.setdefault(loose, comp)
+
+    taken_refs = _collect_cdx_bom_refs(upstream)
+
+    for syft_comp in syft.get("components", []):
+        identity = _cdx_identity(syft_comp)
+        if identity is not None and identity in by_identity:
+            _cdx_fill_empty(by_identity[identity], syft_comp)
+            continue
+
+        loose = _cdx_identity_loose(syft_comp)
+        if loose is not None and loose in by_loose:
+            _cdx_fill_empty(by_loose[loose], syft_comp)
+            continue
+
+        # New component. Ensure bom-ref uniqueness.
+        original = syft_comp.get("bom-ref")
+        if original:
+            new_ref = _unique_bom_ref(original, taken_refs)
+            if new_ref != original:
+                syft_comp["bom-ref"] = new_ref
+            taken_refs.add(new_ref)
+
+        _cdx_set_source(syft_comp, SOURCE_SYFT)
+        components.append(syft_comp)
+
+    return upstream
+
+
+# ---------------------------------------------------------------------------
+# SPDX 2.x merge
+# ---------------------------------------------------------------------------
+
+
+def _spdx_purl(pkg: dict[str, Any]) -> str | None:
+    for ref in pkg.get("externalRefs", []):
+        if ref.get("referenceType") == "purl":
+            locator = ref.get("referenceLocator")
+            if locator:
+                return str(locator)
+    return None
+
+
+def _spdx_identity(pkg: dict[str, Any]) -> tuple[str, str, str, str] | None:
+    return _purl_identity(_spdx_purl(pkg))
+
+
+def _spdx_identity_loose(pkg: dict[str, Any]) -> tuple[str, str, str] | None:
+    return _purl_identity_loose(_spdx_purl(pkg))
+
+
+def _spdx_fill_empty(upstream: dict[str, Any], syft: dict[str, Any]) -> None:
+    for field in (
+        "description",
+        "summary",
+        "supplier",
+        "originator",
+        "licenseDeclared",
+        "licenseConcluded",
+        "copyrightText",
+        "homepage",
+        "sourceInfo",
+    ):
+        up_val = upstream.get(field)
+        if (not up_val or up_val == "NOASSERTION") and syft.get(field) and syft[field] != "NOASSERTION":
+            upstream[field] = syft[field]
+
+    if not upstream.get("checksums") and syft.get("checksums"):
+        upstream["checksums"] = syft["checksums"]
+
+    existing_ext = {
+        (r.get("referenceCategory"), r.get("referenceType"), r.get("referenceLocator"))
+        for r in upstream.get("externalRefs", [])
+    }
+    for ref in syft.get("externalRefs", []):
+        key = (ref.get("referenceCategory"), ref.get("referenceType"), ref.get("referenceLocator"))
+        if key not in existing_ext:
+            upstream.setdefault("externalRefs", []).append(ref)
+            existing_ext.add(key)
+
+
+def _collect_spdx_ids(doc: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    root_id = doc.get("SPDXID")
+    if root_id:
+        ids.add(root_id)
+    for pkg in doc.get("packages", []):
+        pid = pkg.get("SPDXID")
+        if pid:
+            ids.add(pid)
+    for f in doc.get("files", []):
+        fid = f.get("SPDXID")
+        if fid:
+            ids.add(fid)
+    return ids
+
+
+def _unique_spdx_id(candidate: str, taken: set[str]) -> str:
+    if candidate not in taken:
+        return candidate
+    n = 1
+    while True:
+        new = f"{candidate}-syft-{n}"
+        if new not in taken:
+            return new
+        n += 1
+
+
+def merge_spdx(upstream: dict[str, Any], syft: dict[str, Any]) -> dict[str, Any]:
+    """Merge ``syft`` (SPDX 2.x dict) into ``upstream`` (SPDX 2.x dict).
+
+    Mutates and returns ``upstream``. Syft packages whose PURL is already
+    present in upstream are dropped after their non-empty fields fill any
+    upstream gaps. Syft packages with new PURLs (or no PURL at all) are
+    appended; their SPDX IDs and relationships are rewritten to avoid
+    collisions with upstream IDs.
+    """
+    upstream_packages = upstream.setdefault("packages", [])
+
+    by_identity: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    by_loose: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for pkg in upstream_packages:
+        identity = _spdx_identity(pkg)
+        if identity is not None:
+            by_identity[identity] = pkg
+        loose = _spdx_identity_loose(pkg)
+        if loose is not None:
+            by_loose.setdefault(loose, pkg)
+
+    taken_ids = _collect_spdx_ids(upstream)
+
+    # Build remap table so relationships referencing Syft's IDs can be rewritten.
+    id_remap: dict[str, str] = {}
+    upstream_root = upstream.get("SPDXID", "SPDXRef-DOCUMENT")
+    syft_root = syft.get("SPDXID", "SPDXRef-DOCUMENT")
+    id_remap[syft_root] = upstream_root
+
+    new_packages: list[dict[str, Any]] = []
+
+    for syft_pkg in syft.get("packages", []):
+        identity = _spdx_identity(syft_pkg)
+        original_id = syft_pkg.get("SPDXID", "")
+
+        matched = None
+        if identity is not None and identity in by_identity:
+            matched = by_identity[identity]
+        else:
+            loose = _spdx_identity_loose(syft_pkg)
+            if loose is not None and loose in by_loose:
+                matched = by_loose[loose]
+
+        if matched is not None:
+            _spdx_fill_empty(matched, syft_pkg)
+            if original_id:
+                id_remap[original_id] = matched.get("SPDXID", original_id)
+            continue
+
+        if original_id:
+            new_id = _unique_spdx_id(original_id, taken_ids)
+            if new_id != original_id:
+                syft_pkg["SPDXID"] = new_id
+            taken_ids.add(new_id)
+            id_remap[original_id] = new_id
+
+        new_packages.append(syft_pkg)
+
+    upstream_packages.extend(new_packages)
+
+    # Carry over Syft files, rewriting IDs if needed.
+    upstream_files = upstream.setdefault("files", [])
+    for syft_file in syft.get("files", []):
+        original_id = syft_file.get("SPDXID", "")
+        if original_id:
+            new_id = _unique_spdx_id(original_id, taken_ids)
+            if new_id != original_id:
+                syft_file["SPDXID"] = new_id
+            taken_ids.add(new_id)
+            id_remap[original_id] = new_id
+        upstream_files.append(syft_file)
+
+    # Carry over Syft relationships with remapped IDs, deduping by the triple.
+    upstream_rels = upstream.setdefault("relationships", [])
+    existing_rels = {
+        (r.get("spdxElementId"), r.get("relationshipType"), r.get("relatedSpdxElement")) for r in upstream_rels
+    }
+
+    for rel in syft.get("relationships", []):
+        new_rel = dict(rel)
+        for key in ("spdxElementId", "relatedSpdxElement"):
+            val = new_rel.get(key)
+            if val in id_remap:
+                new_rel[key] = id_remap[val]
+
+        triple = (new_rel.get("spdxElementId"), new_rel.get("relationshipType"), new_rel.get("relatedSpdxElement"))
+        if triple in existing_rels:
+            continue
+        existing_rels.add(triple)
+        upstream_rels.append(new_rel)
+
+    # Carry over hasExtractedLicensingInfos from both docs. Packages may refer
+    # to LicenseRef-* identifiers defined here — dropping this section produces
+    # invalid SPDX with dangling license references.
+    upstream_extracted = upstream.setdefault("hasExtractedLicensingInfos", [])
+    seen_license_ids = {e.get("licenseId") for e in upstream_extracted if e.get("licenseId")}
+    for entry in syft.get("hasExtractedLicensingInfos", []):
+        lid = entry.get("licenseId")
+        if lid and lid not in seen_license_ids:
+            upstream_extracted.append(entry)
+            seen_license_ids.add(lid)
+
+    return upstream

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1239,6 +1239,7 @@ def run_pipeline(config: Config) -> None:
 
                     merge_succeeded = False
                     if upstream_spdx:
+                        import copy
                         import tempfile
 
                         syft_tmp_path: str | None = None
@@ -1275,7 +1276,11 @@ def run_pipeline(config: Config) -> None:
                                 merged = merge_cyclonedx(upstream_doc, syft_doc)
                                 actual_spec_version = cdx_spec
                             else:
-                                merged = merge_spdx(dict(upstream_spdx), syft_doc)
+                                # merge_spdx mutates its first argument (nested
+                                # lists of packages, relationships, extracted
+                                # licenses). Deep-copy so the fetched upstream
+                                # doc stays reusable if callers later cache it.
+                                merged = merge_spdx(copy.deepcopy(upstream_spdx), syft_doc)
                                 spdx_version = str(merged.get("spdxVersion", "SPDX-2.3"))
                                 actual_spec_version = spdx_version.replace("SPDX-", "")
                                 if config.spec_version and config.spec_version != actual_spec_version:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1198,15 +1198,128 @@ def run_pipeline(config: Config) -> None:
                     )
 
                 if not chainguard_info:
-                    logger.info(f"Generating SBOM from Docker image: {config.docker_image}")
-                    result = generate_sbom(
-                        docker_image=config.docker_image,
-                        output_file=STEP_1_FILE,
-                        output_format=config.sbom_format,
-                        spec_version=config.spec_version,
+                    # Try Docker Hub upstream SBOM + Syft merge.
+                    #
+                    # Unlike Chainguard (where we bypass Syft), Docker Hub
+                    # images are routinely extended by users. We fetch the
+                    # publisher's authoritative SBOM for the base layers and
+                    # run Syft to catch anything the Dockerfile installed on
+                    # top, then merge (upstream wins on conflict, Syft fills
+                    # empty upstream fields, Syft-only PURLs are overlaid).
+                    from .._generation.chainguard import convert_spdx_to_cyclonedx
+                    from .._generation.dockerhub import (
+                        DOCKERHUB_MERGE_WARNING,
+                        detect_dockerhub_image,
+                        fetch_dockerhub_sbom,
                     )
-                    if not result.success:
-                        raise SBOMGenerationError(result.error_message or "SBOM generation failed")
+                    from .._generation.sbom_merge import merge_cyclonedx, merge_spdx
+
+                    dockerhub_compatible = True
+                    if config.sbom_format == "spdx" and config.spec_version == "3.0.1":
+                        logger.debug("SPDX 3.0.1 requested; skipping Docker Hub upstream SBOM")
+                        dockerhub_compatible = False
+                    elif config.sbom_format == "cyclonedx":
+                        spec = config.spec_version or "1.6"
+                        spec_parts = tuple(int(x) for x in spec.split("."))
+                        if spec_parts < (1, 3):
+                            logger.debug(f"CycloneDX {spec} requested; skipping Docker Hub upstream SBOM")
+                            dockerhub_compatible = False
+
+                    dockerhub_info = detect_dockerhub_image(config.docker_image) if dockerhub_compatible else None
+                    upstream_spdx = None
+                    if dockerhub_info:
+                        logger.info(
+                            f"Detected Docker Hub base image: {dockerhub_info.image_ref} (tier={dockerhub_info.tier})"
+                        )
+                        try:
+                            upstream_spdx = fetch_dockerhub_sbom(dockerhub_info)
+                        except Exception as e:
+                            logger.warning(f"Docker Hub upstream SBOM fetch failed: {e}")
+                            upstream_spdx = None
+
+                    merge_succeeded = False
+                    if upstream_spdx:
+                        import tempfile
+
+                        syft_tmp_path: str | None = None
+                        try:
+                            with tempfile.NamedTemporaryFile(
+                                mode="w",
+                                suffix=".json",
+                                delete=False,
+                                dir=Path(STEP_1_FILE).parent,
+                            ) as tmp:
+                                syft_tmp_path = tmp.name
+
+                            logger.info(
+                                f"Running Syft scan of {config.docker_image} to overlay onto Docker Hub upstream SBOM"
+                            )
+                            syft_result = generate_sbom(
+                                docker_image=config.docker_image,
+                                output_file=syft_tmp_path,
+                                output_format=config.sbom_format,
+                                spec_version=config.spec_version,
+                            )
+                            if not syft_result.success:
+                                raise SBOMGenerationError(
+                                    syft_result.error_message or "Syft scan failed for Docker Hub merge"
+                                )
+
+                            with open(syft_tmp_path, encoding="utf-8") as f:
+                                syft_doc = json.load(f)
+
+                            if config.sbom_format == "cyclonedx":
+                                cdx_spec = config.spec_version or "1.6"
+                                upstream_cdx_json = convert_spdx_to_cyclonedx(upstream_spdx, cdx_spec)
+                                upstream_doc = json.loads(upstream_cdx_json)
+                                merged = merge_cyclonedx(upstream_doc, syft_doc)
+                                actual_spec_version = cdx_spec
+                            else:
+                                merged = merge_spdx(dict(upstream_spdx), syft_doc)
+                                spdx_version = str(merged.get("spdxVersion", "SPDX-2.3"))
+                                actual_spec_version = spdx_version.replace("SPDX-", "")
+                                if config.spec_version and config.spec_version != actual_spec_version:
+                                    logger.warning(
+                                        f"Requested SPDX {config.spec_version} but upstream "
+                                        f"Docker Hub SBOM is SPDX {actual_spec_version}; "
+                                        f"using {actual_spec_version}"
+                                    )
+
+                            with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                                json.dump(merged, f, ensure_ascii=False)
+
+                            gha_warning(
+                                DOCKERHUB_MERGE_WARNING,
+                                title="Docker Hub Image Detected",
+                            )
+                            result = GenerationResult.success_result(
+                                output_file=STEP_1_FILE,
+                                sbom_format=config.sbom_format,
+                                spec_version=actual_spec_version,
+                                generator_name="dockerhub-sbom+syft",
+                            )
+                            merge_succeeded = True
+                        except Exception as e:
+                            logger.warning(
+                                f"Docker Hub upstream SBOM merge failed, falling back to plain Syft scan: {e}"
+                            )
+                        finally:
+                            if syft_tmp_path:
+                                try:
+                                    os.unlink(syft_tmp_path)
+                                except OSError:
+                                    pass
+
+                    if not merge_succeeded:
+                        logger.info(f"Generating SBOM from Docker image: {config.docker_image}")
+                        result = generate_sbom(
+                            docker_image=config.docker_image,
+                            output_file=STEP_1_FILE,
+                            output_format=config.sbom_format,
+                            spec_version=config.spec_version,
+                        )
+                        if not result.success:
+                            raise SBOMGenerationError(result.error_message or "SBOM generation failed")
             elif FILE_TYPE == "LOCK_FILE":
                 logger.info(f"Generating SBOM from lock file: {FILE}")
                 result = process_lock_file(

--- a/tests/test_buildkit_provenance.py
+++ b/tests/test_buildkit_provenance.py
@@ -1,0 +1,345 @@
+"""Tests for the shared BuildKit / in-toto attestation helpers."""
+
+import base64
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from sbomify_action._generation.buildkit_provenance import (
+    SPDX_DOCUMENT,
+    _classify_registry_error,
+    extract_repo,
+    fetch_build_provenance,
+    fetch_buildkit_spdx_attestation,
+    fetch_cosign_spdx_predicate,
+    iter_resolved_dependencies,
+    parse_docker_resolved_dependency,
+    parse_purl_docker_uri,
+    run_cosign,
+    run_crane,
+)
+
+# --- Fixtures ---
+
+MANIFEST_WITH_ATTESTATION = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:imagedigest",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:attdigest",
+                "annotations": {
+                    "vnd.docker.reference.digest": "sha256:imagedigest",
+                    "vnd.docker.reference.type": "attestation-manifest",
+                },
+                "platform": {"architecture": "unknown", "os": "unknown"},
+            },
+        ],
+    }
+)
+
+ATTESTATION_MANIFEST_WITH_SPDX = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "layers": [
+            {
+                "mediaType": "application/vnd.in-toto+json",
+                "digest": "sha256:spdxlayer",
+                "annotations": {"in-toto.io/predicate-type": SPDX_DOCUMENT},
+            },
+            {
+                "mediaType": "application/vnd.in-toto+json",
+                "digest": "sha256:provlayer",
+                "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+            },
+        ],
+    }
+)
+
+SPDX_STATEMENT = json.dumps(
+    {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": SPDX_DOCUMENT,
+        "predicate": {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [{"name": "alpine", "SPDXID": "SPDXRef-alpine"}],
+        },
+    }
+)
+
+
+class TestExtractRepo:
+    def test_simple_tag(self):
+        assert extract_repo("nginx:latest") == "nginx"
+
+    def test_registry_with_port(self):
+        assert extract_repo("localhost:5000/repo/image:tag") == "localhost:5000/repo/image"
+
+    def test_digest_ref(self):
+        assert extract_repo("nginx@sha256:abc") == "nginx"
+
+    def test_no_tag_or_digest(self):
+        assert extract_repo("docker.io/library/python") == "docker.io/library/python"
+
+
+class TestParsePurlDockerUri:
+    def test_parses_digest_from_query(self):
+        uri = "pkg:docker/library/python?digest=sha256:abc&platform=linux%2Famd64"
+        assert parse_purl_docker_uri(uri) == ("library/python", "sha256:abc")
+
+    def test_strips_tag_from_path(self):
+        uri = "pkg:docker/library/python@3.11?digest=sha256:abc"
+        assert parse_purl_docker_uri(uri) == ("library/python", "sha256:abc")
+
+    def test_returns_none_without_digest(self):
+        assert parse_purl_docker_uri("pkg:docker/library/python@3.11?platform=linux%2Famd64") is None
+
+    def test_non_docker_purl(self):
+        assert parse_purl_docker_uri("pkg:npm/vue@3.0.0") is None
+
+
+class TestParseDockerResolvedDependency:
+    def test_digest_from_uri_qualifier(self):
+        dep = {
+            "uri": "pkg:docker/library/python@3.11?digest=sha256:uri-digest&platform=linux%2Famd64",
+            "digest": {"sha256": "field-digest"},
+        }
+        # URI qualifier wins when present.
+        assert parse_docker_resolved_dependency(dep) == ("library/python", "sha256:uri-digest")
+
+    def test_digest_from_sibling_field(self):
+        """Docker Hub BuildKit provenance commonly puts the digest in the sibling field."""
+        dep = {
+            "uri": "pkg:docker/library/python@3.11?platform=linux%2Famd64",
+            "digest": {"sha256": "field-digest"},
+        }
+        assert parse_docker_resolved_dependency(dep) == ("library/python", "sha256:field-digest")
+
+    def test_dhi_ref_with_field_digest(self):
+        dep = {
+            "uri": "pkg:docker/dhi.io/python?platform=linux%2Famd64",
+            "digest": {"sha256": "dhi-digest"},
+        }
+        assert parse_docker_resolved_dependency(dep) == ("dhi.io/python", "sha256:dhi-digest")
+
+    def test_no_query_no_field(self):
+        assert parse_docker_resolved_dependency({"uri": "pkg:docker/library/python"}) is None
+
+    def test_non_docker_uri(self):
+        assert parse_docker_resolved_dependency({"uri": "pkg:npm/left-pad@1.0.0"}) is None
+
+    def test_missing_uri(self):
+        assert parse_docker_resolved_dependency({}) is None
+
+
+class TestIterResolvedDependencies:
+    def test_yields_entries(self):
+        statement = {
+            "predicate": {
+                "buildDefinition": {
+                    "resolvedDependencies": [
+                        {"uri": "pkg:docker/library/python"},
+                        {"uri": "pkg:docker/library/nginx"},
+                    ]
+                }
+            }
+        }
+        deps = list(iter_resolved_dependencies(statement))
+        assert len(deps) == 2
+
+    def test_empty_when_missing(self):
+        assert list(iter_resolved_dependencies({})) == []
+
+
+class TestFetchBuildkitAttestationStatement:
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_fetches_spdx_layer(self, mock_crane):
+        mock_crane.side_effect = [
+            MANIFEST_WITH_ATTESTATION,
+            ATTESTATION_MANIFEST_WITH_SPDX,
+            SPDX_STATEMENT,
+        ]
+
+        predicate = fetch_buildkit_spdx_attestation("docker.io/library/python:3.11")
+        assert predicate is not None
+        assert predicate["spdxVersion"] == "SPDX-2.3"
+        assert predicate["packages"][0]["name"] == "alpine"
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_no_attestation_sibling(self, mock_crane):
+        # Plain manifest list with no attestation-manifest sibling.
+        mock_crane.side_effect = [
+            json.dumps(
+                {
+                    "mediaType": "application/vnd.oci.image.index.v1+json",
+                    "manifests": [
+                        {
+                            "digest": "sha256:x",
+                            "platform": {"architecture": "amd64", "os": "linux"},
+                        }
+                    ],
+                }
+            )
+        ]
+
+        assert fetch_buildkit_spdx_attestation("docker.io/library/old:1.0") is None
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_no_matching_predicate_layer(self, mock_crane):
+        att_with_only_provenance = json.dumps(
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {
+                        "digest": "sha256:provlayer",
+                        "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+                    }
+                ],
+            }
+        )
+        mock_crane.side_effect = [MANIFEST_WITH_ATTESTATION, att_with_only_provenance]
+
+        assert fetch_buildkit_spdx_attestation("docker.io/library/python:3.11") is None
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_fetch_build_provenance_routes_to_provenance_predicate(self, mock_crane):
+        provenance_statement = json.dumps(
+            {
+                "_type": "https://in-toto.io/Statement/v0.1",
+                "predicateType": "https://slsa.dev/provenance/v1",
+                "predicate": {"buildDefinition": {"resolvedDependencies": []}},
+            }
+        )
+        mock_crane.side_effect = [
+            MANIFEST_WITH_ATTESTATION,
+            ATTESTATION_MANIFEST_WITH_SPDX,
+            provenance_statement,
+        ]
+        statement = fetch_build_provenance("user/image:v1")
+        assert statement is not None
+        assert statement["predicateType"] == "https://slsa.dev/provenance/v1"
+
+
+class TestFetchCosignSpdxPredicate:
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
+    def test_extracts_spdx_predicate(self, mock_cosign):
+        payload = {
+            "predicateType": SPDX_DOCUMENT,
+            "predicate": {"spdxVersion": "SPDX-2.3", "packages": []},
+        }
+        envelope = {
+            "payloadType": "application/vnd.in-toto+json",
+            "payload": base64.b64encode(json.dumps(payload).encode()).decode(),
+        }
+        mock_cosign.return_value = json.dumps(envelope)
+
+        predicate = fetch_cosign_spdx_predicate("dhi.io/python@sha256:abc")
+        assert predicate is not None
+        assert predicate["spdxVersion"] == "SPDX-2.3"
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
+    def test_skips_non_spdx_envelopes(self, mock_cosign):
+        provenance_payload = {
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {},
+        }
+        envelope = {"payload": base64.b64encode(json.dumps(provenance_payload).encode()).decode()}
+        mock_cosign.return_value = json.dumps(envelope)
+
+        assert fetch_cosign_spdx_predicate("dhi.io/python@sha256:abc") is None
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
+    def test_extra_args_are_passed(self, mock_cosign):
+        mock_cosign.return_value = ""
+        fetch_cosign_spdx_predicate(
+            "dhi.io/python@sha256:abc",
+            extra_cosign_args=["--key", "https://example/key.pub", "--insecure-ignore-tlog=true"],
+        )
+        call_args = mock_cosign.call_args[0][0]
+        assert "--key" in call_args
+        assert "https://example/key.pub" in call_args
+        assert "--insecure-ignore-tlog=true" in call_args
+
+
+class TestClassifyRegistryError:
+    def test_rate_limit_variants(self):
+        for stderr in [
+            "Error: TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.",
+            "unexpected status: 429 Too Many Requests",
+            "rate limit exceeded",
+        ]:
+            hint = _classify_registry_error(stderr)
+            assert hint is not None
+            assert "docker login" in hint.lower()
+            assert "rate limit" in hint.lower()
+
+    def test_unauthorized(self):
+        stderr = "401 Unauthorized: authentication required"
+        hint = _classify_registry_error(stderr)
+        assert hint is not None
+        assert "docker login" in hint.lower()
+
+    def test_not_found(self):
+        hint = _classify_registry_error("Error: manifest not found (404)")
+        assert hint is not None
+        assert "not found" in hint.lower()
+
+    def test_unknown_error_returns_none(self):
+        assert _classify_registry_error("some other transport failure") is None
+        assert _classify_registry_error("") is None
+
+
+class TestRunCraneSurfacesHints:
+    @patch("sbomify_action._generation.buildkit_provenance.subprocess.run")
+    def test_rate_limit_logged_at_warning(self, mock_run, caplog):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["crane", "manifest", "python:3.11"],
+            returncode=1,
+            stdout="",
+            stderr="Error: TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.",
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="sbomify_action"):
+            with pytest.raises(subprocess.CalledProcessError):
+                run_crane(["manifest", "python:3.11"])
+
+        # At least one WARNING must mention rate limit + docker login.
+        assert any(
+            "rate limit" in rec.message.lower() and "docker login" in rec.message.lower() for rec in caplog.records
+        )
+
+    @patch("sbomify_action._generation.buildkit_provenance.subprocess.run")
+    def test_success_passes_stdout(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["crane", "manifest", "python:3.11"],
+            returncode=0,
+            stdout='{"ok": true}',
+            stderr="",
+        )
+        assert run_crane(["manifest", "python:3.11"]) == '{"ok": true}'
+
+    @patch("sbomify_action._generation.buildkit_provenance.subprocess.run")
+    def test_cosign_401_surfaces(self, mock_run, caplog):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["cosign", "download", "attestation", "dhi.io/python"],
+            returncode=1,
+            stdout="",
+            stderr="GET https://dhi.io/token: 401 Unauthorized",
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="sbomify_action"):
+            with pytest.raises(subprocess.CalledProcessError):
+                run_cosign(["download", "attestation", "dhi.io/python"])
+
+        assert any("docker login" in rec.message.lower() and "401" in rec.message for rec in caplog.records)

--- a/tests/test_buildkit_provenance.py
+++ b/tests/test_buildkit_provenance.py
@@ -282,11 +282,31 @@ class TestClassifyRegistryError:
             assert "docker login" in hint.lower()
             assert "rate limit" in hint.lower()
 
+    def test_rate_limit_hint_is_registry_agnostic(self):
+        """The classifier is shared with Chainguard (cgr.dev), so the 429 hint
+        shouldn't assert 'Docker Hub' as the failing registry."""
+        hint = _classify_registry_error("TOOMANYREQUESTS: limit exceeded")
+        # The Docker Hub quota is still *mentioned* as context, but the hint
+        # doesn't claim Docker Hub IS the failing registry.
+        assert hint is not None
+        assert "<registry>" in hint  # user fills in based on their ref
+
     def test_unauthorized(self):
         stderr = "401 Unauthorized: authentication required"
         hint = _classify_registry_error(stderr)
         assert hint is not None
         assert "docker login" in hint.lower()
+        # DHI-specific remediation surfaced when relevant.
+        assert "dhi.io" in hint
+
+    def test_no_matching_credentials(self):
+        """crane's own 'No matching credentials' — distinct from 401, common
+        for dhi.io when the user has only done `docker login`."""
+        stderr = 'No matching credentials were found for "dhi.io"'
+        hint = _classify_registry_error(stderr)
+        assert hint is not None
+        assert "docker login" in hint.lower()
+        assert "dhi.io" in hint
 
     def test_not_found(self):
         hint = _classify_registry_error("Error: manifest not found (404)")

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -263,13 +263,13 @@ class TestParseDockerPurl:
 
 
 class TestDetectDirectChainguard:
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_direct_chainguard_image(self, mock_crane, mock_which):
         mock_crane.side_effect = [
             # 1. _is_chainguard_config: crane config
             CHAINGUARD_CONFIG,
-            # 2. _resolve_platform_digest: crane manifest (manifest list)
+            # 2. resolve_platform_digest: crane manifest (manifest list)
             MANIFEST_LIST,
         ]
 
@@ -279,8 +279,8 @@ class TestDetectDirectChainguard:
         # Digest depends on current platform (amd64 or arm64)
         assert result.digest.startswith("sha256:")
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_non_chainguard_returns_none(self, mock_crane, mock_which):
         # Not cgr.dev prefix, so tries provenance path
         # crane manifest for provenance detection — return simple manifest (no attestation)
@@ -302,15 +302,15 @@ class TestDetectDirectChainguard:
         result = detect_chainguard_image("nginx:latest")
         assert result is None
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value=None)
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value=None)
     def test_crane_not_available(self, mock_which):
         result = detect_chainguard_image("cgr.dev/chainguard/python:latest")
         assert result is None
 
 
 class TestDetectFromProvenance:
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_detects_chainguard_base_in_provenance(self, mock_crane, mock_which):
         # Resolve platform digest for the found Chainguard image
         chainguard_manifest_list = json.dumps(
@@ -335,7 +335,7 @@ class TestDetectFromProvenance:
             ATTESTATION_MANIFEST,
             # 3. crane blob (provenance)
             PROVENANCE_WITH_CHAINGUARD,
-            # 4. _resolve_platform_digest: crane manifest for the Chainguard image
+            # 4. resolve_platform_digest: crane manifest for the Chainguard image
             chainguard_manifest_list,
         ]
 
@@ -344,8 +344,8 @@ class TestDetectFromProvenance:
         assert result.image_ref == "cgr.dev/chainguard/python"
         assert result.digest.startswith("sha256:")
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_detects_chainguard_with_registry_port(self, mock_crane, mock_which):
         """Ensure provenance detection works with registry:port image refs."""
         chainguard_manifest_list = json.dumps(
@@ -379,8 +379,8 @@ class TestDetectFromProvenance:
         att_call_args = calls[1][0][0]  # first positional arg is the args list
         assert att_call_args[1].startswith("localhost:5000/myorg/myapp@")
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_no_chainguard_in_provenance(self, mock_crane, mock_which):
         mock_crane.side_effect = [
             MANIFEST_WITH_ATTESTATION,
@@ -391,8 +391,8 @@ class TestDetectFromProvenance:
         result = detect_chainguard_image("myapp:latest")
         assert result is None
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
-    @patch("sbomify_action._generation.chainguard._run_crane")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
     def test_no_attestation_manifest(self, mock_crane, mock_which):
         # Image index without attestation manifest
         simple_manifest = json.dumps(
@@ -415,8 +415,8 @@ class TestDetectFromProvenance:
 
 
 class TestFetchChainguardSbom:
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/cosign")
-    @patch("sbomify_action._generation.chainguard._run_cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
     def test_fetches_spdx_sbom(self, mock_cosign, mock_which):
         cosign_output = _make_cosign_attestation_output(SAMPLE_SPDX_SBOM)
         mock_cosign.return_value = cosign_output
@@ -430,8 +430,8 @@ class TestFetchChainguardSbom:
         assert result["spdxVersion"] == "SPDX-2.3"
         assert len(result["packages"]) == 3
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/cosign")
-    @patch("sbomify_action._generation.chainguard._run_cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/local/bin/cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
     def test_no_spdx_attestation_raises(self, mock_cosign, mock_which):
         # Return a non-SPDX attestation
         payload = {"predicateType": "https://slsa.dev/provenance/v1", "predicate": {}}
@@ -444,7 +444,7 @@ class TestFetchChainguardSbom:
         with pytest.raises(RuntimeError, match="No SPDX SBOM found"):
             fetch_chainguard_sbom(info)
 
-    @patch("sbomify_action._generation.chainguard.shutil.which", return_value=None)
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value=None)
     def test_cosign_not_available_raises(self, mock_which):
         info = ChainguardBaseImage(image_ref="cgr.dev/chainguard/python", digest="sha256:abc")
         with pytest.raises(RuntimeError, match="cosign not found"):

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -468,6 +468,34 @@ class TestFetchDockerhubSbom:
         assert "--key" in call_args
         assert "--insecure-ignore-tlog=true" in call_args
 
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
+    def test_dhi_uses_verify_attestation_not_download(self, mock_cosign, mock_which):
+        """Regression guard: DHI must invoke `cosign verify-attestation` so
+        Docker's signature is actually checked. Downgrading to `download
+        attestation` would silently accept tampered SBOMs."""
+        payload = {
+            "predicateType": SPDX_DOCUMENT,
+            "predicate": {"spdxVersion": "SPDX-2.3", "packages": []},
+        }
+        envelope = {"payload": base64.b64encode(json.dumps(payload).encode()).decode()}
+        mock_cosign.return_value = json.dumps(envelope)
+
+        info = DockerHubBaseImage(
+            image_ref="dhi.io/python",
+            index_ref="dhi.io/python:latest",
+            digest="sha256:dhidigest",
+            tier="dhi",
+        )
+        fetch_dockerhub_sbom(info)
+
+        call_args = mock_cosign.call_args[0][0]
+        assert call_args[0] == "verify-attestation"
+        # --type spdxjson so cosign filters for SPDX-shaped attestations.
+        assert "--type" in call_args
+        assert "spdxjson" in call_args
+        assert "download" not in call_args
+
     @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value=None)
     def test_dhi_without_cosign_returns_none(self, mock_which):
         info = DockerHubBaseImage(

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -1,0 +1,479 @@
+"""Tests for Docker Hub base image detection and upstream SBOM fetch."""
+
+import base64
+import json
+from unittest.mock import patch
+
+from sbomify_action._generation.buildkit_provenance import SPDX_DOCUMENT
+from sbomify_action._generation.dockerhub import (
+    DockerHubBaseImage,
+    _classify_ref,
+    detect_dockerhub_image,
+    fetch_dockerhub_sbom,
+)
+
+# --- Fixtures ---
+
+MANIFEST_LIST_PLAIN = json.dumps(
+    {
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "digest": "sha256:amd64digest",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "digest": "sha256:arm64digest",
+                "platform": {"architecture": "arm64", "os": "linux"},
+            },
+        ],
+    }
+)
+
+MANIFEST_LIST_WITH_ATTESTATION = json.dumps(
+    {
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "digest": "sha256:imagedigest",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "digest": "sha256:attdigest",
+                "annotations": {
+                    "vnd.docker.reference.digest": "sha256:imagedigest",
+                    "vnd.docker.reference.type": "attestation-manifest",
+                },
+                "platform": {"architecture": "unknown", "os": "unknown"},
+            },
+        ],
+    }
+)
+
+ATTESTATION_MANIFEST_WITH_SPDX = json.dumps(
+    {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "layers": [
+            {
+                "digest": "sha256:spdxlayer",
+                "annotations": {"in-toto.io/predicate-type": SPDX_DOCUMENT},
+            }
+        ],
+    }
+)
+
+PYTHON_SPDX_STATEMENT = json.dumps(
+    {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": SPDX_DOCUMENT,
+        "predicate": {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [
+                {"name": "debian-base", "SPDXID": "SPDXRef-base"},
+                {"name": "libssl3", "SPDXID": "SPDXRef-libssl"},
+            ],
+        },
+    }
+)
+
+PROVENANCE_WITH_DOCKERHUB_BASE = json.dumps(
+    {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/library/python@3.11?platform=linux%2Famd64",
+                        "digest": {"sha256": "pythondigest"},
+                    }
+                ]
+            }
+        },
+    }
+)
+
+PROVENANCE_WITH_DHI_BASE = json.dumps(
+    {
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/dhi.io/python@latest?platform=linux%2Famd64",
+                        "digest": {"sha256": "dhidigest"},
+                    }
+                ]
+            }
+        },
+    }
+)
+
+PROVENANCE_WITH_CUSTOM_BASE = json.dumps(
+    {
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/ghcr.io/user/custom@v1?platform=linux%2Famd64",
+                        "digest": {"sha256": "customdigest"},
+                    }
+                ]
+            }
+        },
+    }
+)
+
+
+# --- Classification ---
+
+
+class TestClassifyRef:
+    def test_bare_name(self):
+        assert _classify_ref("python") == "official"
+        assert _classify_ref("python:3.11") == "official"
+
+    def test_library_shorthand(self):
+        assert _classify_ref("library/nginx") == "official"
+        assert _classify_ref("library/nginx:alpine") == "official"
+
+    def test_full_docker_io_library(self):
+        assert _classify_ref("docker.io/library/redis") == "official"
+        assert _classify_ref("docker.io/library/redis:7") == "official"
+        assert _classify_ref("index.docker.io/library/redis") == "official"
+
+    def test_dhi(self):
+        assert _classify_ref("dhi.io/python") == "dhi"
+        assert _classify_ref("dhi.io/python:3.11") == "dhi"
+
+    def test_docker_io_user_repo_not_official(self):
+        assert _classify_ref("docker.io/myuser/myapp") is None
+
+    def test_implicit_user_repo_not_official(self):
+        # two-part shorthand without "library/" prefix → user/repo on Docker Hub
+        assert _classify_ref("myuser/myapp") is None
+
+    def test_other_registries(self):
+        assert _classify_ref("ghcr.io/foo/bar") is None
+        assert _classify_ref("gcr.io/proj/img") is None
+        assert _classify_ref("quay.io/org/img") is None
+        assert _classify_ref("localhost:5000/foo/bar") is None
+
+
+# --- Direct detection ---
+
+
+class TestDetectDirect:
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_library_shorthand(self, mock_crane, mock_which):
+        mock_crane.side_effect = [MANIFEST_LIST_PLAIN]
+
+        result = detect_dockerhub_image("library/python:3.11")
+        assert result is not None
+        assert result.tier == "official"
+        assert result.image_ref == "docker.io/library/python"
+        assert result.digest.startswith("sha256:")
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_bare_name(self, mock_crane, mock_which):
+        mock_crane.side_effect = [MANIFEST_LIST_PLAIN]
+
+        result = detect_dockerhub_image("python:3.11")
+        assert result is not None
+        assert result.tier == "official"
+        assert result.image_ref == "docker.io/library/python"
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_dhi(self, mock_crane, mock_which):
+        mock_crane.side_effect = [MANIFEST_LIST_PLAIN]
+
+        result = detect_dockerhub_image("dhi.io/python:latest")
+        assert result is not None
+        assert result.tier == "dhi"
+        assert result.image_ref == "dhi.io/python"
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_other_registry_returns_none(self, mock_crane, mock_which):
+        # Provenance path will also be attempted — give it an empty manifest.
+        mock_crane.side_effect = [
+            json.dumps({"mediaType": "application/vnd.oci.image.index.v1+json", "manifests": []}),
+        ]
+        result = detect_dockerhub_image("ghcr.io/foo/bar:latest")
+        assert result is None
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value=None)
+    def test_crane_not_available(self, mock_which):
+        result = detect_dockerhub_image("python:3.11")
+        assert result is None
+
+
+# --- Provenance detection ---
+
+
+class TestDetectFromProvenance:
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_detects_library_base(self, mock_crane, mock_which):
+        python_manifest_list = json.dumps(
+            {
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "digest": "sha256:pythonamd64",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                    {
+                        "digest": "sha256:pythonarm64",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+        mock_crane.side_effect = [
+            # 1. Direct detection path: user's image is ghcr.io/... (not a hub image),
+            # _classify_ref returns None → _detect_direct returns None without calling crane.
+            # 2. Provenance path: image index w/ attestation
+            MANIFEST_LIST_WITH_ATTESTATION,
+            # 3. attestation manifest — contains provenance layer too (not just SPDX)
+            json.dumps(
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "layers": [
+                        {
+                            "digest": "sha256:provlayer",
+                            "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+                        }
+                    ],
+                }
+            ),
+            # 4. provenance blob
+            PROVENANCE_WITH_DOCKERHUB_BASE,
+            # 5. resolve_platform_digest for the found base
+            python_manifest_list,
+        ]
+
+        result = detect_dockerhub_image("ghcr.io/myorg/myapp:v1")
+        assert result is not None
+        assert result.tier == "official"
+        assert result.image_ref == "docker.io/library/python"
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_detects_dhi_base(self, mock_crane, mock_which):
+        dhi_manifest_list = json.dumps(
+            {
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "digest": "sha256:dhiamd64",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                    {
+                        "digest": "sha256:dhiarm64",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+        mock_crane.side_effect = [
+            MANIFEST_LIST_WITH_ATTESTATION,
+            json.dumps(
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "layers": [
+                        {
+                            "digest": "sha256:provlayer",
+                            "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+                        }
+                    ],
+                }
+            ),
+            PROVENANCE_WITH_DHI_BASE,
+            dhi_manifest_list,
+        ]
+
+        result = detect_dockerhub_image("ghcr.io/myorg/app:v1")
+        assert result is not None
+        assert result.tier == "dhi"
+        assert result.image_ref == "dhi.io/python"
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/crane")
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_ignores_non_dockerhub_base(self, mock_crane, mock_which):
+        mock_crane.side_effect = [
+            MANIFEST_LIST_WITH_ATTESTATION,
+            json.dumps(
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "layers": [
+                        {
+                            "digest": "sha256:provlayer",
+                            "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+                        }
+                    ],
+                }
+            ),
+            PROVENANCE_WITH_CUSTOM_BASE,
+        ]
+
+        result = detect_dockerhub_image("ghcr.io/myorg/app:v1")
+        assert result is None
+
+
+# --- SBOM fetch ---
+
+
+class TestFetchDockerhubSbom:
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_official_fetches_via_crane(self, mock_crane):
+        mock_crane.side_effect = [
+            MANIFEST_LIST_WITH_ATTESTATION,
+            ATTESTATION_MANIFEST_WITH_SPDX,
+            PYTHON_SPDX_STATEMENT,
+        ]
+        info = DockerHubBaseImage(
+            image_ref="docker.io/library/python",
+            index_ref="docker.io/library/python:3.11",
+            digest="sha256:imagedigest",
+            tier="official",
+        )
+        result = fetch_dockerhub_sbom(info)
+        assert result is not None
+        assert result["spdxVersion"] == "SPDX-2.3"
+        assert len(result["packages"]) == 2
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_official_multi_arch_picks_matching_sibling(self, mock_crane):
+        """Multi-arch indexes have one attestation-manifest per platform.
+        Must pick the sibling whose vnd.docker.reference.digest equals our
+        platform digest — otherwise we'd fetch another platform's SBOM."""
+        multi_arch_index = json.dumps(
+            {
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "digest": "sha256:amd64image",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                    {
+                        "digest": "sha256:amd64att",
+                        "annotations": {
+                            "vnd.docker.reference.digest": "sha256:amd64image",
+                            "vnd.docker.reference.type": "attestation-manifest",
+                        },
+                        "platform": {"architecture": "unknown", "os": "unknown"},
+                    },
+                    {
+                        "digest": "sha256:arm64image",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                    },
+                    {
+                        "digest": "sha256:arm64att",
+                        "annotations": {
+                            "vnd.docker.reference.digest": "sha256:arm64image",
+                            "vnd.docker.reference.type": "attestation-manifest",
+                        },
+                        "platform": {"architecture": "unknown", "os": "unknown"},
+                    },
+                ],
+            }
+        )
+        arm64_att_manifest = json.dumps(
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {
+                        "digest": "sha256:arm64spdx",
+                        "annotations": {"in-toto.io/predicate-type": SPDX_DOCUMENT},
+                    }
+                ],
+            }
+        )
+        arm64_spdx = json.dumps(
+            {
+                "predicateType": SPDX_DOCUMENT,
+                "predicate": {
+                    "spdxVersion": "SPDX-2.3",
+                    "packages": [{"name": "arm64-pkg"}],
+                },
+            }
+        )
+        mock_crane.side_effect = [multi_arch_index, arm64_att_manifest, arm64_spdx]
+
+        info = DockerHubBaseImage(
+            image_ref="docker.io/library/python",
+            index_ref="docker.io/library/python:3.11",
+            digest="sha256:arm64image",
+            tier="official",
+        )
+        result = fetch_dockerhub_sbom(info)
+        assert result is not None
+        assert result["packages"][0]["name"] == "arm64-pkg"
+
+        # Second crane call should have fetched the arm64 attestation manifest.
+        second_call_args = mock_crane.call_args_list[1][0][0]
+        assert second_call_args[1].endswith("@sha256:arm64att")
+
+    @patch("sbomify_action._generation.buildkit_provenance.run_crane")
+    def test_official_no_attestation_returns_none(self, mock_crane):
+        """Some older Official Images don't ship SBOM attestations."""
+        mock_crane.side_effect = [
+            json.dumps(
+                {
+                    "mediaType": "application/vnd.oci.image.index.v1+json",
+                    "manifests": [
+                        {
+                            "digest": "sha256:only",
+                            "platform": {"architecture": "amd64", "os": "linux"},
+                        }
+                    ],
+                }
+            )
+        ]
+        info = DockerHubBaseImage(
+            image_ref="docker.io/library/old",
+            index_ref="docker.io/library/old:1.0",
+            digest="sha256:only",
+            tier="official",
+        )
+        assert fetch_dockerhub_sbom(info) is None
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value="/usr/bin/cosign")
+    @patch("sbomify_action._generation.buildkit_provenance.run_cosign")
+    def test_dhi_fetches_via_cosign_with_key_and_tlog_flags(self, mock_cosign, mock_which):
+        payload = {
+            "predicateType": SPDX_DOCUMENT,
+            "predicate": {"spdxVersion": "SPDX-2.3", "packages": [{"name": "dhi-pkg"}]},
+        }
+        envelope = {"payload": base64.b64encode(json.dumps(payload).encode()).decode()}
+        mock_cosign.return_value = json.dumps(envelope)
+
+        info = DockerHubBaseImage(
+            image_ref="dhi.io/python",
+            index_ref="dhi.io/python:latest",
+            digest="sha256:dhidigest",
+            tier="dhi",
+        )
+        result = fetch_dockerhub_sbom(info)
+        assert result is not None
+        assert result["spdxVersion"] == "SPDX-2.3"
+
+        # Verify the DHI-specific flags were passed through.
+        call_args = mock_cosign.call_args[0][0]
+        assert "--key" in call_args
+        assert "--insecure-ignore-tlog=true" in call_args
+
+    @patch("sbomify_action._generation.buildkit_provenance.shutil.which", return_value=None)
+    def test_dhi_without_cosign_returns_none(self, mock_which):
+        info = DockerHubBaseImage(
+            image_ref="dhi.io/python",
+            index_ref="dhi.io/python:latest",
+            digest="sha256:dhidigest",
+            tier="dhi",
+        )
+        assert fetch_dockerhub_sbom(info) is None

--- a/tests/test_sbom_merge.py
+++ b/tests/test_sbom_merge.py
@@ -84,6 +84,49 @@ class TestMergeCycloneDX:
         # Syft should not add a new overlay for this PURL.
         assert _get_prop(openssl, SBOMIFY_SOURCE_PROP) == SOURCE_DOCKERHUB
 
+    def test_external_references_dedup_by_type_and_url(self):
+        """Same URL under different type (e.g., vcs vs website) must NOT
+        collapse — they carry distinct semantic information."""
+        upstream = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "purl": "pkg:deb/debian/pkg@1",
+                    "bom-ref": "u-pkg",
+                    "externalReferences": [
+                        {"type": "website", "url": "https://example.org/pkg"},
+                    ],
+                },
+            ],
+        }
+        syft = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "purl": "pkg:deb/debian/pkg@1",
+                    "bom-ref": "s-pkg",
+                    "externalReferences": [
+                        # Same URL but different type — should NOT be treated
+                        # as a duplicate of upstream's website ref.
+                        {"type": "vcs", "url": "https://example.org/pkg"},
+                        # Truly identical — should dedupe away.
+                        {"type": "website", "url": "https://example.org/pkg"},
+                        # Different URL — should be added.
+                        {"type": "website", "url": "https://example.org/other"},
+                    ],
+                },
+            ],
+        }
+        merged = merge_cyclonedx(upstream, syft)
+        refs = merged["components"][0]["externalReferences"]
+        # Expected: upstream's website ref + syft's vcs ref + syft's other-URL website ref.
+        keys = sorted((r["type"], r["url"]) for r in refs)
+        assert keys == [
+            ("vcs", "https://example.org/pkg"),
+            ("website", "https://example.org/other"),
+            ("website", "https://example.org/pkg"),
+        ]
+
     def test_overlapping_purl_fills_empty_fields(self):
         upstream = {
             "components": [

--- a/tests/test_sbom_merge.py
+++ b/tests/test_sbom_merge.py
@@ -1,0 +1,413 @@
+"""Tests for the upstream-wins SBOM merge logic."""
+
+from sbomify_action._generation.sbom_merge import (
+    SBOMIFY_SOURCE_PROP,
+    SOURCE_DOCKERHUB,
+    SOURCE_SYFT,
+    merge_cyclonedx,
+    merge_spdx,
+)
+
+# --- Helpers ---
+
+
+def _get_prop(comp, name):
+    for p in comp.get("properties", []):
+        if p.get("name") == name:
+            return p.get("value")
+    return None
+
+
+def _find_by_name(items, name):
+    for c in items:
+        if c.get("name") == name:
+            return c
+    return None
+
+
+# --- CycloneDX tests ---
+
+
+class TestMergeCycloneDX:
+    def test_disjoint_purls_unions(self):
+        upstream = {
+            "components": [
+                {"name": "libc", "purl": "pkg:deb/debian/libc@2.36", "bom-ref": "u-libc"},
+            ],
+        }
+        syft = {
+            "components": [
+                {"name": "requests", "purl": "pkg:pypi/requests@2.31", "bom-ref": "s-requests"},
+            ],
+        }
+
+        merged = merge_cyclonedx(upstream, syft)
+        assert len(merged["components"]) == 2
+
+        libc = _find_by_name(merged["components"], "libc")
+        requests = _find_by_name(merged["components"], "requests")
+
+        assert _get_prop(libc, SBOMIFY_SOURCE_PROP) == SOURCE_DOCKERHUB
+        assert _get_prop(requests, SBOMIFY_SOURCE_PROP) == SOURCE_SYFT
+
+    def test_overlapping_purl_upstream_wins(self):
+        upstream = {
+            "components": [
+                {
+                    "name": "openssl",
+                    "purl": "pkg:deb/debian/openssl@3.0.13",
+                    "version": "3.0.13",
+                    "description": "upstream desc",
+                    "licenses": [{"license": {"id": "Apache-2.0"}}],
+                    "bom-ref": "u-openssl",
+                },
+            ],
+        }
+        syft = {
+            "components": [
+                {
+                    "name": "openssl",
+                    "purl": "pkg:deb/debian/openssl@3.0.13",
+                    "version": "3.0.13",
+                    "description": "syft desc — should not overwrite",
+                    "licenses": [{"license": {"id": "MIT"}}],
+                    "bom-ref": "s-openssl",
+                },
+            ],
+        }
+
+        merged = merge_cyclonedx(upstream, syft)
+        assert len(merged["components"]) == 1
+        openssl = merged["components"][0]
+        assert openssl["description"] == "upstream desc"
+        assert openssl["licenses"][0]["license"]["id"] == "Apache-2.0"
+        # Syft should not add a new overlay for this PURL.
+        assert _get_prop(openssl, SBOMIFY_SOURCE_PROP) == SOURCE_DOCKERHUB
+
+    def test_overlapping_purl_fills_empty_fields(self):
+        upstream = {
+            "components": [
+                {
+                    "name": "libx",
+                    "purl": "pkg:deb/debian/libx@1.0",
+                    "bom-ref": "u-libx",
+                    # description, licenses, supplier all missing
+                },
+            ],
+        }
+        syft = {
+            "components": [
+                {
+                    "name": "libx",
+                    "purl": "pkg:deb/debian/libx@1.0",
+                    "description": "syft description",
+                    "licenses": [{"license": {"id": "MIT"}}],
+                    "supplier": {"name": "Syft supplier"},
+                    "externalReferences": [{"type": "website", "url": "https://example.org/libx"}],
+                },
+            ],
+        }
+
+        merged = merge_cyclonedx(upstream, syft)
+        libx = merged["components"][0]
+        assert libx["description"] == "syft description"
+        assert libx["licenses"][0]["license"]["id"] == "MIT"
+        assert libx["supplier"]["name"] == "Syft supplier"
+        assert any(r.get("url") == "https://example.org/libx" for r in libx.get("externalReferences", []))
+
+    def test_bom_ref_collision_rewritten(self):
+        upstream = {
+            "components": [
+                {"name": "a", "purl": "pkg:deb/debian/a@1", "bom-ref": "ref-1"},
+            ],
+        }
+        syft = {
+            "components": [
+                # Same bom-ref as upstream but different PURL → should be renamed.
+                {"name": "b", "purl": "pkg:pypi/b@2", "bom-ref": "ref-1"},
+            ],
+        }
+        merged = merge_cyclonedx(upstream, syft)
+        refs = {c["bom-ref"] for c in merged["components"]}
+        assert "ref-1" in refs
+        assert len(refs) == 2
+
+    def test_syft_component_without_purl_is_added(self):
+        upstream = {"components": []}
+        syft = {"components": [{"name": "mystery", "bom-ref": "s-mystery"}]}
+        merged = merge_cyclonedx(upstream, syft)
+        assert len(merged["components"]) == 1
+        assert _get_prop(merged["components"][0], SBOMIFY_SOURCE_PROP) == SOURCE_SYFT
+
+    def test_purl_namespace_mismatch_falls_back_to_loose(self):
+        """Amazon Linux's upstream BuildKit SBOM emits
+        ``pkg:rpm/amazonlinux/bash@...`` while Syft emits ``pkg:rpm/amzn/bash@...``.
+        Same package, but different namespace defeats strict identity. The
+        loose-fallback dedup (type+name+version) must catch this."""
+        upstream = {
+            "components": [
+                {
+                    "name": "bash",
+                    "version": "4.2.46-34.amzn2",
+                    "purl": "pkg:rpm/amazonlinux/bash@4.2.46-34.amzn2?os_name=amazonlinux&os_version=2",
+                    "bom-ref": "u-bash",
+                },
+            ],
+        }
+        syft = {
+            "components": [
+                {
+                    "name": "bash",
+                    "version": "4.2.46-34.amzn2",
+                    "purl": "pkg:rpm/amzn/bash@4.2.46-34.amzn2?arch=x86_64&distro=amzn-2",
+                    "bom-ref": "s-bash",
+                    "description": "The GNU Bourne Again SHell",
+                },
+            ],
+        }
+        merged = merge_cyclonedx(upstream, syft)
+        assert len(merged["components"]) == 1
+        bash = merged["components"][0]
+        # Upstream's PURL is preserved.
+        assert bash["purl"] == "pkg:rpm/amazonlinux/bash@4.2.46-34.amzn2?os_name=amazonlinux&os_version=2"
+        # But syft's description filled the empty upstream field.
+        assert bash["description"] == "The GNU Bourne Again SHell"
+
+    def test_purl_qualifiers_ignored_in_dedup(self):
+        """Same package emitted with different qualifier styles by different
+        generators must still dedupe. Docker/BuildKit uses
+        ``os_distro=trixie&os_name=debian&os_version=13`` while Syft uses
+        ``arch=amd64&distro=debian-13`` — same deb package, though."""
+        upstream = {
+            "components": [
+                {
+                    "name": "acl",
+                    "version": "2.3.2-2",
+                    "purl": "pkg:deb/debian/acl@2.3.2-2?os_distro=trixie&os_name=debian&os_version=13",
+                    "bom-ref": "u-acl",
+                },
+            ],
+        }
+        syft = {
+            "components": [
+                {
+                    "name": "acl",
+                    "version": "2.3.2-2",
+                    "purl": "pkg:deb/debian/acl@2.3.2-2?arch=amd64&distro=debian-13&upstream=acl",
+                    "bom-ref": "s-acl",
+                    "description": "Access control list utilities",
+                },
+            ],
+        }
+        merged = merge_cyclonedx(upstream, syft)
+        # Should collapse to one component — upstream wins, gets syft's description.
+        assert len(merged["components"]) == 1
+        acl = merged["components"][0]
+        # Upstream's PURL is preserved (upstream wins).
+        assert "os_distro=trixie" in acl["purl"]
+        assert acl["description"] == "Access control list utilities"
+
+
+# --- SPDX tests ---
+
+
+def _spdx_pkg(spdx_id, name, version=None, purl=None, **fields):
+    pkg = {"SPDXID": spdx_id, "name": name, "downloadLocation": "NOASSERTION"}
+    if version:
+        pkg["versionInfo"] = version
+    if purl:
+        pkg["externalRefs"] = [
+            {
+                "referenceCategory": "PACKAGE-MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": purl,
+            }
+        ]
+    pkg.update(fields)
+    return pkg
+
+
+class TestMergeSpdx:
+    def test_disjoint_purls_unions(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [_spdx_pkg("SPDXRef-libc", "libc", "2.36", "pkg:deb/debian/libc@2.36")],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [_spdx_pkg("SPDXRef-req", "requests", "2.31", "pkg:pypi/requests@2.31")],
+        }
+        merged = merge_spdx(upstream, syft)
+        names = {p["name"] for p in merged["packages"]}
+        assert names == {"libc", "requests"}
+
+    def test_overlapping_purl_upstream_wins(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [
+                _spdx_pkg(
+                    "SPDXRef-openssl",
+                    "openssl",
+                    "3.0.13",
+                    "pkg:deb/debian/openssl@3.0.13",
+                    description="upstream desc",
+                    licenseDeclared="Apache-2.0",
+                ),
+            ],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [
+                _spdx_pkg(
+                    "SPDXRef-openssl-syft",
+                    "openssl",
+                    "3.0.13",
+                    "pkg:deb/debian/openssl@3.0.13",
+                    description="syft desc — should not overwrite",
+                    licenseDeclared="MIT",
+                ),
+            ],
+        }
+        merged = merge_spdx(upstream, syft)
+        assert len(merged["packages"]) == 1
+        openssl = merged["packages"][0]
+        assert openssl["description"] == "upstream desc"
+        assert openssl["licenseDeclared"] == "Apache-2.0"
+
+    def test_fills_empty_upstream_fields_and_noassertion(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [
+                _spdx_pkg(
+                    "SPDXRef-libx",
+                    "libx",
+                    "1.0",
+                    "pkg:deb/debian/libx@1.0",
+                    licenseDeclared="NOASSERTION",
+                ),
+            ],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [
+                _spdx_pkg(
+                    "SPDXRef-libx-syft",
+                    "libx",
+                    "1.0",
+                    "pkg:deb/debian/libx@1.0",
+                    description="syft description",
+                    licenseDeclared="MIT",
+                    supplier="Organization: Syft Supplier",
+                ),
+            ],
+        }
+        merged = merge_spdx(upstream, syft)
+        libx = merged["packages"][0]
+        assert libx["description"] == "syft description"
+        assert libx["licenseDeclared"] == "MIT"
+        assert libx["supplier"] == "Organization: Syft Supplier"
+
+    def test_spdx_id_collision_rewritten(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [_spdx_pkg("SPDXRef-pkg", "a", "1", "pkg:deb/debian/a@1")],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            # Same SPDXID but different PURL → rename.
+            "packages": [_spdx_pkg("SPDXRef-pkg", "b", "2", "pkg:pypi/b@2")],
+        }
+        merged = merge_spdx(upstream, syft)
+        ids = {p["SPDXID"] for p in merged["packages"]}
+        assert "SPDXRef-pkg" in ids
+        assert len(ids) == 2
+
+    def test_extracted_licensing_infos_carried_over(self):
+        """Syft emits LicenseRef-<hash> identifiers in package license fields
+        that are defined in hasExtractedLicensingInfos. Dropping that section
+        produces invalid SPDX with dangling license references."""
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [_spdx_pkg("SPDXRef-base", "base", "1", "pkg:deb/base@1")],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [
+                _spdx_pkg(
+                    "SPDXRef-extra",
+                    "extra",
+                    "1",
+                    "pkg:pypi/extra@1",
+                    licenseDeclared="LicenseRef-custom-1",
+                ),
+            ],
+            "hasExtractedLicensingInfos": [
+                {"licenseId": "LicenseRef-custom-1", "extractedText": "Custom license text"},
+                {"licenseId": "LicenseRef-custom-2", "extractedText": "Another"},
+            ],
+        }
+        merged = merge_spdx(upstream, syft)
+        license_ids = {e["licenseId"] for e in merged.get("hasExtractedLicensingInfos", [])}
+        assert license_ids == {"LicenseRef-custom-1", "LicenseRef-custom-2"}
+
+    def test_extracted_licensing_infos_deduped(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [],
+            "hasExtractedLicensingInfos": [
+                {"licenseId": "LicenseRef-shared", "extractedText": "upstream version"},
+            ],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [],
+            "hasExtractedLicensingInfos": [
+                # Same licenseId — upstream wins, Syft entry is dropped.
+                {"licenseId": "LicenseRef-shared", "extractedText": "syft version"},
+                {"licenseId": "LicenseRef-syft-only", "extractedText": "syft-only"},
+            ],
+        }
+        merged = merge_spdx(upstream, syft)
+        entries = {e["licenseId"]: e["extractedText"] for e in merged["hasExtractedLicensingInfos"]}
+        assert entries == {
+            "LicenseRef-shared": "upstream version",
+            "LicenseRef-syft-only": "syft-only",
+        }
+
+    def test_relationships_remapped(self):
+        upstream = {
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "packages": [_spdx_pkg("SPDXRef-base", "base", "1", "pkg:deb/base@1")],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-base",
+                }
+            ],
+        }
+        syft = {
+            "SPDXID": "SPDXRef-syft-doc",
+            "packages": [_spdx_pkg("SPDXRef-extra", "extra", "1", "pkg:pypi/extra@1")],
+            "relationships": [
+                {
+                    "spdxElementId": "SPDXRef-syft-doc",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": "SPDXRef-extra",
+                }
+            ],
+        }
+        merged = merge_spdx(upstream, syft)
+        # The Syft DOCUMENT relationship should be remapped to upstream's DOCUMENT SPDXID.
+        describes_upstream = any(
+            r["spdxElementId"] == "SPDXRef-DOCUMENT" and r["relatedSpdxElement"] == "SPDXRef-extra"
+            for r in merged["relationships"]
+        )
+        assert describes_upstream
+        # Dedup: original upstream DESCRIBES of SPDXRef-base still present, only once.
+        base_rel_count = sum(
+            1
+            for r in merged["relationships"]
+            if r["relatedSpdxElement"] == "SPDXRef-base" and r["relationshipType"] == "DESCRIBES"
+        )
+        assert base_rel_count == 1


### PR DESCRIPTION
## Summary

- Detect Docker Official Images (`library/*`) and Docker Hardened Images (`dhi.io/*`) — either directly via `DOCKER_IMAGE` or via BuildKit SLSA provenance on a user-built image — and fetch the publisher's SPDX SBOM.
- Merge that upstream SBOM with a local Syft scan of the same image: upstream wins for base-layer packages, Syft fills gaps and overlays packages installed by the user's Dockerfile (`apt`, `pip`, `COPY`, …). Components are tagged with a `sbomify:source` property (`docker-hub-upstream` or `syft-overlay`) for auditability.
- Factor the crane/cosign + in-toto walking code out of `chainguard.py` into a shared `buildkit_provenance` module so both detectors use the same primitives. Fixes a latent bug along the way: multi-arch indexes have one `attestation-manifest` sibling per platform, and the previous code sometimes pulled the wrong one (or nothing) when given a per-platform digest.
- Surface registry failures clearly — Docker Hub rate limits (100 anonymous pulls / 6h), 401s, and 404s now log at WARNING with the concrete remediation (`docker login`, `docker login dhi.io`, etc.) instead of silently falling back.

Full pipeline verified end-to-end with `--augment` (local `sbomify.json`) and `--enrich`: the merge output passes through both stages unmodified in shape, source tags preserved.

Dedup keys on the PURL's core identity, ignoring qualifiers (Docker's `os_distro=trixie&os_name=debian` vs Syft's `arch=amd64&distro=debian-13` both collapse to the same package). A second-pass *loose* match (type + name + version, namespace ignored) catches the cases where the two generators disagree on namespace — for example, Amazon Linux's upstream SBOM emits `pkg:rpm/amazonlinux/bash` while Syft emits `pkg:rpm/amzn/bash`. Safe because a merge always describes a single image, so the distro is fixed.

## Test plan

Unit coverage — 79 new tests, full suite 2257 passing, ruff clean:
- [x] `tests/test_buildkit_provenance.py` — crane/cosign helpers, rate-limit/401/404 classifier
- [x] `tests/test_dockerhub.py` — direct + provenance detection for `library/*`, `dhi.io/*`, ref classification, multi-arch sibling matching
- [x] `tests/test_sbom_merge.py` — strict dedup, qualifier-ignore fallback, namespace-mismatch fallback, relationship/extracted-license carry-over
- [x] `tests/test_chainguard.py` — existing tests rewired to the shared module; no behavioral change

Runnable E2E (`examples/docker-hub/run-e2e.sh` — 7 scenarios):
- [x] `python:3.11-slim` direct, CycloneDX — 142 upstream + 2721 overlay
- [x] `python:3.11-slim` direct, SPDX — 157 packages, 72 extracted licenses, **0 validation errors**
- [x] Distro sweep: `alpine:3.20`, `ubuntu:24.04`, `rockylinux:9`, `amazonlinux:2`, `archlinux:latest`, `busybox:latest` — all detected, merged, deduped across `pkg:deb`/`pkg:apk`/`pkg:rpm`/`pkg:alpm`/`pkg:generic`
- [x] Built `FROM python:3.11-slim` + `apt`/`pip`, CycloneDX — 142 upstream + 2852 overlay, `requests`/`click`/`curl`/`jq` all present as `syft-overlay`
- [x] Same, SPDX — 188 packages, 105 extracted licenses, 0 validation errors
- [x] Full merge + `--augment` (local `sbomify.json`) + `--enrich` — supplier, authors, lifecycle applied on top of merged SBOM
- [ ] DHI end-to-end — skipped in this environment (dhi.io needs `docker login dhi.io` and account entitlement). Unit-tested cosign shape includes `--key https://registry.scout.docker.com/keyring/dhi/latest.pub` and `--insecure-ignore-tlog=true`; the keyring URL is verified publicly reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)