### PR TITLE
feat(wizard): add Publish step — generate & upload first SBOMs locally

### DIFF
--- a/sbomify_action/cli/wizard/app.py
+++ b/sbomify_action/cli/wizard/app.py
@@ -18,8 +18,11 @@ Phases (``step_index`` on each ``WizardScreen``):
                             (when augmentation=json_config) push to
                             configure (sbomify.json) for the in-repo
                             metadata form
-  8. review + apply + done — table of planned writes → RichLog progress
-                             → summary panel + OIDC instructions
+  8. review + apply        — table of planned writes → RichLog progress
+  9. publish + done        — optional local generate-and-upload of the
+                             first SBOMs (one pipeline subprocess per
+                             matrix row) → summary panel + OIDC
+                             instructions
 """
 
 from __future__ import annotations

--- a/sbomify_action/cli/wizard/ci_emitter.py
+++ b/sbomify_action/cli/wizard/ci_emitter.py
@@ -18,6 +18,7 @@ import functools
 import logging
 import re
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 
 import requests
@@ -184,17 +185,34 @@ def _format_extension(fmt: SbomFormat) -> str:
     return "cdx.json" if fmt == "cyclonedx" else "spdx.json"
 
 
-def _matrix_block(
+@dataclass(frozen=True)
+class MatrixRow:
+    """One (component, format) row of the emitted workflow's matrix.
+
+    Shared between the YAML emitter and the wizard's Publish step so a
+    local publish run and the CI job agree on component id, lockfile,
+    format, and output filename for every row.
+    """
+
+    name: str
+    component_name: str
+    component_id: str
+    lockfile: str
+    sbom_format: SbomFormat
+    output_file: str
+
+
+def matrix_rows(
     components: list[PlannedComponent],
     formats: list[SbomFormat],
     component_ids: dict[str, str],
-) -> str:
-    """Render the ``matrix.include:`` rows — one per (component, format).
+) -> list[MatrixRow]:
+    """Compute the matrix rows — one per (component, format).
 
     Row ``name`` is suffixed with the format only when more than one
     format is being emitted, so single-format workflows stay readable.
     """
-    rows: list[str] = []
+    rows: list[MatrixRow] = []
     multi_format = len(formats) > 1
     # Track which component-name slugs are reused across lockfiles. When two
     # lockfiles map to the same name (eg the user accepts the same suggested
@@ -219,17 +237,34 @@ def _matrix_block(
             row_slug = name_slug
         for fmt in formats:
             ext = _format_extension(fmt)
-            row_name = f"{row_slug}-{fmt}" if multi_format else row_slug
-            output_file = f"{row_slug}.{ext}"
             rows.append(
-                "          - name: " + row_name + "\n"
-                "            component_name: " + c.name + "\n"
-                "            component_id: " + cid + "\n"
-                "            lockfile: " + rel + "\n"
-                "            sbom_format: " + fmt + "\n"
-                "            output_file: " + output_file + "\n"
+                MatrixRow(
+                    name=f"{row_slug}-{fmt}" if multi_format else row_slug,
+                    component_name=c.name,
+                    component_id=cid,
+                    lockfile=rel,
+                    sbom_format=fmt,
+                    output_file=f"{row_slug}.{ext}",
+                )
             )
-    return "".join(rows)
+    return rows
+
+
+def _matrix_block(
+    components: list[PlannedComponent],
+    formats: list[SbomFormat],
+    component_ids: dict[str, str],
+) -> str:
+    """Render the ``matrix.include:`` rows from :func:`matrix_rows`."""
+    return "".join(
+        "          - name: " + row.name + "\n"
+        "            component_name: " + row.component_name + "\n"
+        "            component_id: " + row.component_id + "\n"
+        "            lockfile: " + row.lockfile + "\n"
+        "            sbom_format: " + row.sbom_format + "\n"
+        "            output_file: " + row.output_file + "\n"
+        for row in matrix_rows(components, formats, component_ids)
+    )
 
 
 def _trigger_block(strategy: ReleaseStrategy, branch: str, lockfile_paths: list[str]) -> str:

--- a/sbomify_action/cli/wizard/publish.py
+++ b/sbomify_action/cli/wizard/publish.py
@@ -141,10 +141,16 @@ def _build_env(run: PublishRun, state: WizardState, opts: WizardOptions, version
     product release named after a random commit SHA as a side effect of
     onboarding would be surprising. Releases stay CI's job.
     """
+    # The wizard's authenticate screen always constructs the client with
+    # the token string the user entered, but the client's type allows
+    # None (other flows construct it tokenless). Coerce for typing; an
+    # empty TOKEN would fail the subprocess's own config validation with
+    # a clear "token is required" error rather than anything silent.
+    token = state.require_api().token or ""
     env = {k: v for k, v in os.environ.items() if k not in _PIPELINE_ENV_VARS}
     env.update(
         {
-            "TOKEN": state.require_api().token,
+            "TOKEN": token,
             "COMPONENT_ID": run.row.component_id,
             "COMPONENT_NAME": run.row.component_name,
             "LOCK_FILE": run.row.lockfile,
@@ -174,6 +180,7 @@ def _stream_subprocess(
     interleaving. Isolated as a module-level function so tests can stub
     the subprocess boundary without faking ``Popen``.
     """
+    # nosemgrep: dangerous-subprocess-use-audit  # list-form, shell=False, fixed executable (sys.executable -c <constant>)
     proc = subprocess.Popen(  # noqa: S603 — argv is built from wizard state, not user shell input
         cmd,
         env=env,

--- a/sbomify_action/cli/wizard/publish.py
+++ b/sbomify_action/cli/wizard/publish.py
@@ -1,0 +1,300 @@
+"""``run_publish`` — the wizard's local generate-and-upload step.
+
+Runs after ``apply_plan`` has created the components and written the
+workflow file: each (lockfile, format) matrix row the workflow would
+run in CI is executed locally, once, so the user leaves the wizard with
+their first SBOMs already on sbomify instead of waiting for the first
+push to trigger CI.
+
+Each row runs as a subprocess of this interpreter (see
+``_PIPELINE_BOOTSTRAP``) rather than an in-process ``run_pipeline``
+call. That's deliberate: the pipeline configures global logging, chdirs
+via WORKING_DIR handling, mutates the process-wide audit trail, and
+exits with ``sys.exit`` on failure — none of which can be allowed to
+happen inside the Textual app's process. A subprocess also exercises
+exactly the code path the emitted workflow will run in CI.
+
+The subprocess env mirrors the workflow's ``env:`` block, with one
+difference: CI authenticates via OIDC or the SBOMIFY_TOKEN secret,
+while the local run reuses the session token the user already entered
+on the Authenticate screen.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from sbomify_action.cli.wizard.ci_emitter import MatrixRow, augmentation_to_env, matrix_rows
+from sbomify_action.cli.wizard.options import WizardOptions
+from sbomify_action.cli.wizard.state import PublishOutcome, WizardState
+
+LogKind = Literal["info", "success", "warning", "error", "output"]
+LogFn = Callable[[LogKind, str], None]
+
+
+def _noop(_kind: LogKind, _message: str) -> None:
+    """Default log sink — used when no UI is attached (eg. tests)."""
+
+
+# Pipeline configuration env vars scrubbed from the inherited environment
+# before each run. Anything the user happens to have exported (a stray
+# DOCKER_IMAGE, a leftover SBOM_FILE from manual testing) would otherwise
+# silently redirect the run away from the lockfile the wizard planned.
+_PIPELINE_ENV_VARS = (
+    "TOKEN",
+    "COMPONENT_ID",
+    "COMPONENT_NAME",
+    "COMPONENT_VERSION",
+    "COMPONENT_PURL",
+    "SBOM_VERSION",
+    "OVERRIDE_NAME",
+    "OVERRIDE_SBOM_METADATA",
+    "SBOM_FILE",
+    "LOCK_FILE",
+    "DOCKER_IMAGE",
+    "UPLOAD",
+    "UPLOAD_DESTINATIONS",
+    "AUGMENT",
+    "ENRICH",
+    "PRODUCT_RELEASE",
+    "API_BASE_URL",
+    "SBOM_FORMAT",
+    "OUTPUT_FILE",
+    "BOM_TYPE",
+    "SPEC_VERSION",
+    "OIDC_AUDIENCE",
+    "WORKING_DIR",
+)
+
+
+# Bootstrap for the pipeline subprocess. ``-c`` rather than ``-m
+# sbomify_action.cli.main``: the wizard process has already imported the
+# module, and runpy re-executing an imported module prints a
+# RuntimeWarning that would land as noise at the top of every publish
+# log. It also avoids depending on the ``sbomify-action`` console script
+# being on PATH. Configuration travels entirely via env vars (the same
+# contract the GitHub Action uses), so no argv is needed.
+_PIPELINE_BOOTSTRAP = "from sbomify_action.cli.main import main; main()"
+
+
+@dataclass(frozen=True)
+class PublishRun:
+    """One planned local pipeline invocation."""
+
+    row: MatrixRow
+    output_path: Path
+    """Absolute path the run writes its final SBOM to — ``row.output_file``
+    inside the session's publish output dir, never the repo working tree."""
+
+
+def component_version(repo_root: Path) -> str | None:
+    """The version stamped on locally published SBOMs.
+
+    Mirrors the emitted workflow's non-tag fallback (``git rev-parse
+    --short HEAD``): trunk/manual strategies always use the short SHA,
+    and tag-strategy dispatch runs fall back to it too, so the short SHA
+    is the one version every strategy agrees on. ``None`` (version
+    omitted) when git can't answer — eg. a repo with no commits yet.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    sha = proc.stdout.strip()
+    return sha or None
+
+
+def build_publish_runs(state: WizardState, output_dir: Path) -> list[PublishRun]:
+    """Plan one run per (lockfile, format) — the same rows CI would run.
+
+    Uses the real component IDs ``apply_plan`` recorded on
+    ``state.component_ids``, so a row can never carry the
+    ``REPLACE_WITH_COMPONENT_ID`` placeholder here (apply always runs
+    first and populates every planned component's ID).
+    """
+    plan = state.plan
+    component_ids = {str(rel): cid for rel, cid in state.component_ids.items()}
+    rows = matrix_rows(plan.create_components, plan.sbom_formats or ["cyclonedx"], component_ids)
+    return [PublishRun(row=row, output_path=output_dir / row.output_file) for row in rows]
+
+
+def _build_env(run: PublishRun, state: WizardState, opts: WizardOptions, version: str | None) -> dict[str, str]:
+    """Subprocess environment for one run — the workflow's ``env:`` block,
+    with the session token standing in for OIDC / the repo secret.
+
+    ``PRODUCT_RELEASE`` is intentionally NOT set even for tag-strategy
+    plans: the local publish stamps a short-SHA version, and cutting a
+    product release named after a random commit SHA as a side effect of
+    onboarding would be surprising. Releases stay CI's job.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _PIPELINE_ENV_VARS}
+    env.update(
+        {
+            "TOKEN": state.require_api().token,
+            "COMPONENT_ID": run.row.component_id,
+            "COMPONENT_NAME": run.row.component_name,
+            "LOCK_FILE": run.row.lockfile,
+            "UPLOAD": "true",
+            "AUGMENT": augmentation_to_env(state.plan.augmentation),
+            "ENRICH": "true" if state.plan.enrich else "false",
+            "SBOM_FORMAT": run.row.sbom_format,
+            "OUTPUT_FILE": str(run.output_path),
+            "API_BASE_URL": opts.api_base_url,
+        }
+    )
+    if version:
+        env["COMPONENT_VERSION"] = version
+    return env
+
+
+def _stream_subprocess(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    cwd: Path,
+    on_line: Callable[[str], None],
+) -> int:
+    """Run ``cmd``, forwarding each output line to ``on_line``. Returns the exit code.
+
+    stderr is merged into stdout so the log preserves the pipeline's own
+    interleaving. Isolated as a module-level function so tests can stub
+    the subprocess boundary without faking ``Popen``.
+    """
+    proc = subprocess.Popen(  # noqa: S603 — argv is built from wizard state, not user shell input
+        cmd,
+        env=env,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert proc.stdout is not None  # stdout=PIPE above
+    for line in proc.stdout:
+        on_line(line.rstrip("\n"))
+    return proc.wait()
+
+
+def run_publish(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -> bool:
+    """Execute every planned run sequentially. Returns True iff all succeeded.
+
+    Best-effort by design: a failed run is logged and recorded on
+    ``state.publish_outcomes`` but never aborts the remaining runs and
+    never raises — the workflow file is already on disk, so CI will
+    publish on the next push regardless of what happens here.
+
+    Sequential rather than parallel: generators and enrichment already
+    parallelise internally, the pipeline writes fixed-name step files
+    (``step_1.json``…) into the working directory that concurrent runs
+    would clobber, and an interleaved log would be unreadable anyway.
+    """
+    state.publish_outcomes = []
+    output_dir = Path(tempfile.mkdtemp(prefix="sbomify-wizard-publish-"))
+    state.publish_output_dir = output_dir
+    runs = build_publish_runs(state, output_dir)
+
+    if not runs:
+        log("warning", "Nothing to publish — no components were applied.")
+        return True
+
+    if opts.dry_run:
+        _run_publish_dry_run(state, runs, log)
+        return True
+
+    version = component_version(opts.repo_root)
+    all_ok = True
+    for i, run in enumerate(runs, start=1):
+        row = run.row
+        log("info", "")
+        log(
+            "info",
+            f"[{i}/{len(runs)}] {row.component_name} — {row.lockfile} → {row.sbom_format}",
+        )
+        env = _build_env(run, state, opts, version)
+        cmd = [sys.executable, "-c", _PIPELINE_BOOTSTRAP]
+        try:
+            # cwd must be the repo root: LOCK_FILE is repo-relative (same as
+            # the CI matrix), and the augmentation providers resolve
+            # sbomify.json / git VCS facts from the working directory.
+            exit_code = _stream_subprocess(
+                cmd,
+                env=env,
+                cwd=opts.repo_root,
+                on_line=lambda line: log("output", line),
+            )
+        except OSError as exc:
+            exit_code = -1
+            log("error", f"Could not start the pipeline: {exc}")
+            error: str | None = str(exc)
+        else:
+            error = None if exit_code == 0 else f"pipeline exited with code {exit_code}"
+
+        ok = exit_code == 0
+        state.publish_outcomes.append(
+            PublishOutcome(
+                rel_path=row.lockfile,
+                sbom_format=row.sbom_format,
+                output_file=run.output_path,
+                ok=ok,
+                error=error,
+            )
+        )
+        if ok:
+            log("success", f"Published {row.component_name} ({row.sbom_format}) to sbomify")
+        else:
+            all_ok = False
+            log("error", f"Publish failed for {row.component_name} ({row.sbom_format}): {error}")
+
+    log("info", "")
+    if all_ok:
+        log("success", f"All {len(runs)} SBOM(s) published. Files kept in {output_dir}")
+    else:
+        failed = sum(1 for o in state.publish_outcomes if not o.ok)
+        log(
+            "warning",
+            f"{failed} of {len(runs)} run(s) failed — the CI workflow will retry on the next push. "
+            "Scroll up for the pipeline output of the failed run(s).",
+        )
+    return all_ok
+
+
+def _run_publish_dry_run(state: WizardState, runs: list[PublishRun], log: LogFn) -> None:
+    """Preview the runs without spawning any pipeline subprocess.
+
+    Populates ``state.publish_outcomes`` with ok=True markers so the
+    Done screen can render a "would publish" preview panel;
+    ``state.is_dry_run`` (set by the apply pass) drives the phrasing.
+    """
+    log("info", "Dry-run mode — no SBOMs are generated or uploaded.")
+    for run in runs:
+        row = run.row
+        log(
+            "info",
+            f"[dry-run] Would generate {row.output_file} from {row.lockfile} "
+            f"({row.sbom_format}) and upload it to component {row.component_id}",
+        )
+        state.publish_outcomes.append(
+            PublishOutcome(
+                rel_path=row.lockfile,
+                sbom_format=row.sbom_format,
+                output_file=run.output_path,
+                ok=True,
+            )
+        )
+    log("info", "")
+    log("info", "Re-run without --dry-run to actually publish.")

--- a/sbomify_action/cli/wizard/screens/_base.py
+++ b/sbomify_action/cli/wizard/screens/_base.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from sbomify_action.cli.wizard.app import WizardApp
 
 
-TOTAL_STEPS = 8
+TOTAL_STEPS = 9
 
 # Responsive breakpoints (terminal cells). The wizard is a fit-to-viewport
 # TUI — nothing scrolls — so every screen has to render inside whatever the

--- a/sbomify_action/cli/wizard/screens/apply.py
+++ b/sbomify_action/cli/wizard/screens/apply.py
@@ -191,6 +191,6 @@ class ApplyScreen(WizardScreen):
                 # but defend in depth.
                 self.app.pop_screen()
                 return
-            from sbomify_action.cli.wizard.screens.done import DoneScreen
+            from sbomify_action.cli.wizard.screens.publish import PublishScreen
 
-            self.wizard.push_screen(DoneScreen())
+            self.wizard.push_screen(PublishScreen())

--- a/sbomify_action/cli/wizard/screens/done.py
+++ b/sbomify_action/cli/wizard/screens/done.py
@@ -13,7 +13,7 @@ from sbomify_action.cli.wizard.screens._base import WizardScreen
 class DoneScreen(WizardScreen):
     """Phase 6c — summary + next steps."""
 
-    step_index = 8
+    step_index = 9
     step_title = "Done"
     step_subtitle = "All set. Here's what you'll want to do next."
 
@@ -38,6 +38,24 @@ class DoneScreen(WizardScreen):
         applied.border_subtitle = "From zero to SBOM hero"
         with applied:
             yield Static(self._applied_summary(), classes="wizard-muted")
+
+        # Publish step outcome — only when the user actually ran it
+        # (Skip leaves publish_outcomes empty and this panel absent, so
+        # the Done screen reads exactly as it did before the step existed).
+        outcomes = self.wizard.state.publish_outcomes
+        if outcomes:
+            failed = [o for o in outcomes if not o.ok]
+            if self.wizard.state.is_dry_run:
+                published = Vertical(classes="wizard-panel")
+                published.border_title = "◌  Publish (dry-run preview)"
+            elif failed:
+                published = Vertical(classes="wizard-panel")
+                published.border_title = f"⚠  Published {len(outcomes) - len(failed)} of {len(outcomes)} SBOM(s)"
+            else:
+                published = Vertical(classes="wizard-panel-emphasis")
+                published.border_title = "✓  First SBOMs published"
+            with published:
+                yield Static(self._published_summary(), classes="wizard-muted")
 
         if self.wizard.state.plan.credential_mode == "oidc":
             state = self.wizard.state
@@ -156,6 +174,38 @@ class DoneScreen(WizardScreen):
                 lines.append(f"[#86EFAC]✓[/]  [#CBCCCE]Wrote[/]      {path}")
         if not lines:
             lines.append("[#5E5E5E]◌  (nothing applied)[/]")
+        return "\n".join(lines)
+
+    def _published_summary(self) -> str:
+        """One line per publish run + where the local SBOM files live.
+
+        Dry-run renders "would publish" phrasing since nothing was
+        generated or uploaded; error strings are escaped because they
+        quote subprocess/exception text that can contain ``[``.
+        """
+        from rich.markup import escape as _esc
+
+        state = self.wizard.state
+        lines: list[str] = []
+        for outcome in state.publish_outcomes:
+            label = f"{outcome.rel_path}  [#5E5E5E]({outcome.sbom_format})[/]"
+            if state.is_dry_run:
+                lines.append(f"[#5E5E5E]◌  would publish[/]  {label}")
+            elif outcome.ok:
+                lines.append(f"[#86EFAC]✓[/]  [#CBCCCE]Published[/]  {label}")
+            else:
+                reason = _esc(outcome.error or "failed")
+                lines.append(f"[#F87171]✗[/]  [#CBCCCE]Failed   [/]  {label}  [#5E5E5E]{reason}[/]")
+        if state.is_dry_run:
+            lines.append("")
+            lines.append("[#5E5E5E]Re-run without --dry-run to actually publish.[/]")
+        else:
+            if any(not o.ok for o in state.publish_outcomes):
+                lines.append("")
+                lines.append("[#5E5E5E]Failed runs are not fatal — CI retries on the next push.[/]")
+            if state.publish_output_dir:
+                lines.append("")
+                lines.append(f"[#5E5E5E]Generated files kept in {_esc(str(state.publish_output_dir))}[/]")
         return "\n".join(lines)
 
     def _oidc_success(self) -> str:

--- a/sbomify_action/cli/wizard/screens/help.py
+++ b/sbomify_action/cli/wizard/screens/help.py
@@ -34,6 +34,7 @@ _HELP_BODY = (
     "  06  Configure (SBOM content)\n"
     "  07  Review the plan (diff before commit)\n"
     "  08  Apply — write workflow + finalise components\n"
+    "  09  Publish — generate & upload your first SBOMs (optional)\n"
     "\n"
     "[#5E5E5E]Press [b]?[/] or [b]Esc[/] to close this help.[/]"
 )

--- a/sbomify_action/cli/wizard/screens/publish.py
+++ b/sbomify_action/cli/wizard/screens/publish.py
@@ -1,0 +1,213 @@
+"""Publish screen — generate and upload the first SBOMs locally."""
+
+from __future__ import annotations
+
+from rich.markup import escape as rich_escape
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, RichLog, Static
+from textual.worker import Worker, WorkerState
+
+from sbomify_action.cli.wizard import publish as publish_mod
+from sbomify_action.cli.wizard.ci_emitter import matrix_rows
+from sbomify_action.cli.wizard.screens._base import WizardScreen
+
+# Same palette as the Apply screen's log (see styles.tcss for the token
+# names), plus a muted "output" tier for raw pipeline lines so the
+# wizard's own status lines stand out from the subprocess firehose.
+_COLOR_BY_KIND = {
+    "info": "#CBCCCE",  # tertiaryText
+    "success": "#86EFAC",  # brand-coherent mint
+    "warning": "#F4B57F",  # gradient peach
+    "error": "#F87171",  # soft red, pairs with the dark theme
+    "output": "#5E5E5E",  # muted — raw pipeline output
+}
+
+
+class PublishScreen(WizardScreen):
+    """Phase 9 — run the pipeline locally so the first SBOMs land now.
+
+    Unlike Apply (which auto-starts on mount), publishing waits for an
+    explicit button press: it spawns real pipeline subprocesses that can
+    take minutes (generation + enrichment) and it's genuinely optional —
+    the workflow file is already written, so skipping just means CI does
+    the first publish on the next push instead.
+    """
+
+    step_index = 9
+    step_title = "Publish"
+    step_subtitle = "Optional — publish your first SBOMs now instead of waiting for CI."
+
+    BINDINGS = [
+        Binding("enter", "advance", "Publish ▸", show=True, priority=True),
+        Binding("escape", "back_if_not_running", "Back", show=True, priority=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        # "idle" until the user presses Publish, "running" while the
+        # worker is streaming, "done" once it finished (either way).
+        self._phase: str = "idle"
+        self._had_failures = False
+        # Captured from the DOM on the main thread in ``on_mount`` so the
+        # worker thread never queries widgets directly (DOM traversal is
+        # not thread-safe in Textual).
+        self._log_widget: RichLog | None = None
+
+    def compose_body(self) -> ComposeResult:
+        # Failure banner sits ABOVE the log so it survives the log
+        # scrolling past the lines that caused it. Hidden until needed.
+        banner = Static("", id="publish-banner", markup=True)
+        banner.display = False
+
+        panel = Vertical(classes="wizard-panel", id="publish-panel")
+        panel.border_title = "⏫  First publish"
+        panel.border_subtitle = f"{len(self._rows())} run(s) planned"
+        with panel:
+            yield Static(self._planned_markup(), classes="wizard-muted", id="publish-planned")
+            yield banner
+            yield RichLog(id="publish-log", wrap=True, markup=True, highlight=False)
+        with Horizontal(classes="button-row"):
+            yield Button("◂ Back", id="back")
+            yield Button("Skip ▸", id="skip")
+            yield Button("Publish now ▸", id="publish", variant="primary")
+
+    def on_mount(self) -> None:
+        self._log_widget = self.query_one("#publish-log", RichLog)
+        self.query_one("#publish", Button).focus()
+
+    def _rows(self) -> list:
+        """The planned matrix rows — same helper the emitted workflow used."""
+        state = self.wizard.state
+        component_ids = {str(rel): cid for rel, cid in state.component_ids.items()}
+        return matrix_rows(
+            state.plan.create_components,
+            state.plan.sbom_formats or ["cyclonedx"],
+            component_ids,
+        )
+
+    def _planned_markup(self) -> str:
+        """One line per planned run + a note on credentials and skipping."""
+        lines = [
+            f"  [#8A7DFF]▸[/]  {rich_escape(row.component_name)}  "
+            f"[#5E5E5E]{rich_escape(row.lockfile)}[/]  [#CBCCCE]→ {row.sbom_format}[/]"
+            for row in self._rows()
+        ]
+        lines.append("")
+        lines.append(
+            "[#5E5E5E]Runs the same pipeline your new workflow runs in CI, using this "
+            "wizard session's token. Skipping is fine — CI publishes on the next push.[/]"
+        )
+        return "\n".join(lines)
+
+    def action_advance(self) -> None:
+        self.route_enter(self._advance)
+
+    def action_back_if_not_running(self) -> None:
+        """Escape pops back, but never mid-publish — a run in flight would
+        keep uploading with nobody watching the log."""
+        if self._phase != "running":
+            self.app.pop_screen()
+
+    def _advance(self) -> None:
+        if self._phase == "idle":
+            self._start_publish()
+        elif self._phase == "done":
+            self._continue_to_done()
+
+    def _start_publish(self) -> None:
+        self._phase = "running"
+        for button_id in ("back", "skip", "publish"):
+            self.query_one(f"#{button_id}", Button).disabled = True
+        panel = self.query_one("#publish-panel", Vertical)
+        panel.border_subtitle = "publishing…"
+        self.run_worker(self._publish_worker, name="publish", thread=True, exclusive=True)
+
+    def _publish_worker(self) -> bool:
+        """Run run_publish on a worker thread; returns its all-ok flag.
+
+        Textual widgets are not thread-safe, so every log line hops back
+        to the main thread via ``app.call_from_thread``.
+        """
+        log_widget = self._log_widget
+        assert log_widget is not None  # set in on_mount, before the button can start us
+        app = self.app
+
+        def log(kind: str, message: str) -> None:
+            # Raw pipeline output is high-volume — render it muted and
+            # unprefixed so the wizard's own status lines stay scannable.
+            # Everything is untrusted text (subprocess output, exception
+            # text); escape so a stray `[` can't break markup parsing.
+            colour = _COLOR_BY_KIND.get(kind, "white")
+            if kind == "output":
+                line = f"[{colour}]{rich_escape(message)}[/]"
+            else:
+                line = f"[{colour}]{kind:>8}[/]  {rich_escape(message)}"
+            app.call_from_thread(log_widget.write, line)
+
+        return publish_mod.run_publish(self.wizard.state, self.wizard.opts, log=log)
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.worker.name != "publish":
+            return
+        if event.state not in (WorkerState.SUCCESS, WorkerState.ERROR):
+            return
+        self._phase = "done"
+        back_btn = self.query_one("#back", Button)
+        skip_btn = self.query_one("#skip", Button)
+        publish_btn = self.query_one("#publish", Button)
+        back_btn.disabled = False
+        skip_btn.display = False
+        panel = self.query_one("#publish-panel", Vertical)
+
+        if event.state == WorkerState.ERROR:
+            # run_publish is written to never raise; defend anyway. The
+            # step stays best-effort, so Continue remains available.
+            self._had_failures = True
+            error_text = str(event.worker.error)
+            if self._log_widget is not None:
+                self._log_widget.write(f"[#F87171]worker error: {rich_escape(error_text)}[/]")
+            self._show_banner(error_text)
+            all_ok = False
+        else:
+            all_ok = bool(event.worker.result)
+            if not all_ok:
+                self._had_failures = True
+                self._show_banner("Some runs failed — see the log above. The CI workflow will retry on the next push.")
+
+        if all_ok:
+            panel.border_title = "✓  Published"
+            panel.border_subtitle = "ready to finish"
+        else:
+            panel.border_title = "⚠  Published with failures"
+            panel.border_subtitle = "CI will retry on the next push"
+        publish_btn.label = "Continue ▸"
+        publish_btn.disabled = False
+        publish_btn.focus()
+
+    def _show_banner(self, message: str) -> None:
+        try:
+            banner = self.query_one("#publish-banner", Static)
+        except Exception:  # noqa: BLE001
+            return
+        banner.update(f"[#F4B57F]⚠  {rich_escape(message)}[/]")
+        banner.display = True
+
+    def _continue_to_done(self) -> None:
+        from sbomify_action.cli.wizard.screens.done import DoneScreen
+
+        self.wizard.push_screen(DoneScreen())
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            if self._phase != "running":
+                self.app.pop_screen()
+            return
+        if event.button.id == "skip":
+            # Explicitly not publishing — leave publish_outcomes empty so
+            # the Done screen renders exactly as it did pre-publish-step.
+            self._continue_to_done()
+            return
+        if event.button.id == "publish":
+            self._advance()

--- a/sbomify_action/cli/wizard/screens/publish.py
+++ b/sbomify_action/cli/wizard/screens/publish.py
@@ -10,7 +10,7 @@ from textual.widgets import Button, RichLog, Static
 from textual.worker import Worker, WorkerState
 
 from sbomify_action.cli.wizard import publish as publish_mod
-from sbomify_action.cli.wizard.ci_emitter import matrix_rows
+from sbomify_action.cli.wizard.ci_emitter import MatrixRow, matrix_rows
 from sbomify_action.cli.wizard.screens._base import WizardScreen
 
 # Same palette as the Apply screen's log (see styles.tcss for the token
@@ -77,7 +77,7 @@ class PublishScreen(WizardScreen):
         self._log_widget = self.query_one("#publish-log", RichLog)
         self.query_one("#publish", Button).focus()
 
-    def _rows(self) -> list:
+    def _rows(self) -> list[MatrixRow]:
         """The planned matrix rows — same helper the emitted workflow used."""
         state = self.wizard.state
         component_ids = {str(rel): cid for rel, cid in state.component_ids.items()}

--- a/sbomify_action/cli/wizard/screens/welcome.py
+++ b/sbomify_action/cli/wizard/screens/welcome.py
@@ -185,6 +185,7 @@ class WelcomeScreen(WizardScreen):
             "[#8A7DFF]06[/]  Configure SBOM content (enrichment / formats / provenance)",
             "[#8A7DFF]07[/]  Review the plan",
             "[#8A7DFF]08[/]  Apply — write the workflow file & finalise components",
+            "[#8A7DFF]09[/]  Publish — generate & upload your first SBOMs (optional)",
         ]
 
     def _repo_lines(self) -> list[str]:

--- a/sbomify_action/cli/wizard/state.py
+++ b/sbomify_action/cli/wizard/state.py
@@ -183,6 +183,23 @@ class Plan:
     step after each SBOM upload to produce a signed build attestation."""
 
 
+@dataclass(frozen=True)
+class PublishOutcome:
+    """Result of one local generate-and-upload run from the Publish step.
+
+    One outcome per (lockfile, format) matrix row — mirrors the rows the
+    emitted workflow would run in CI. ``error`` carries a short
+    human-readable reason when ``ok`` is False; the full subprocess
+    output already streamed to the Publish screen's log.
+    """
+
+    rel_path: str
+    sbom_format: str
+    output_file: Path
+    ok: bool
+    error: str | None = None
+
+
 @dataclass
 class WizardState:
     """All wizard state, shared across screens via the Textual App."""
@@ -259,6 +276,16 @@ class WizardState:
     "copy first URL to clipboard" action whose synthetic
     ``<dry-run:component:...>`` IDs would produce a 404 URL."""
 
+    # Populated by publish.run_publish (the Publish screen's worker).
+    publish_outcomes: list[PublishOutcome] = field(default_factory=list)
+    """One entry per attempted (lockfile, format) run, in run order.
+    Empty when the user skipped the Publish step (or hasn't reached it).
+    The Done screen renders a published-SBOMs panel from this."""
+    publish_output_dir: Path | None = None
+    """Directory the local publish runs wrote their SBOM files (and audit
+    trails) into — a session temp dir, kept after the wizard exits so the
+    user can inspect what was uploaded."""
+
     def require_api(self) -> "SbomifyApiClient":
         """Return the API client, raising if authenticate hasn't run yet."""
         if self.api is None:
@@ -286,6 +313,11 @@ class WizardState:
         self.oidc_failed_components = {}
         self.oidc_binding_note = None
         self.is_dry_run = False
+        # Publish runs against the component IDs a specific apply produced;
+        # re-applying invalidates them, so a stale outcome list must not leak
+        # into the Done summary of the new pass.
+        self.publish_outcomes = []
+        self.publish_output_dir = None
 
     def __repr__(self) -> str:
         return (

--- a/sbomify_action/cli/wizard/styles.tcss
+++ b/sbomify_action/cli/wizard/styles.tcss
@@ -385,6 +385,23 @@ PickOrCreate > OptionList {
     max-height: 20;
 }
 
+/* Publish screen — unlike #apply-log, the publish log streams the full
+ * pipeline output of each subprocess (hundreds of lines), so the panel
+ * is the screen's 1fr flex region (like #diff-panel) and the log
+ * scrolls inside it. The planned-runs list above the log stays
+ * content-sized. */
+#publish-panel {
+    height: 1fr;
+}
+
+#publish-log {
+    height: 1fr;
+}
+
+#publish-planned {
+    height: auto;
+}
+
 SelectionList:focus, OptionList:focus, ListView:focus {
     border: tall $sbom-purple;
 }

--- a/tests/test_wizard_publish.py
+++ b/tests/test_wizard_publish.py
@@ -1,0 +1,433 @@
+"""Tests for the wizard's Publish step (local generate-and-upload).
+
+Covers the pure planning helpers (``matrix_rows`` / ``build_publish_runs`` /
+``_build_env``), the ``run_publish`` orchestration with the subprocess
+boundary stubbed out, and the Done screen's published-SBOMs summary text
+(same ``__new__`` + stubbed ``wizard`` property pattern as
+test_wizard_done.py — full composition is covered by the Textual smoke
+tests).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sbomify_action.cli.wizard import publish as publish_mod
+from sbomify_action.cli.wizard.ci_emitter import matrix_rows
+from sbomify_action.cli.wizard.options import WizardOptions
+from sbomify_action.cli.wizard.screens.done import DoneScreen
+from sbomify_action.cli.wizard.state import (
+    DiscoveredLockfile,
+    Plan,
+    PlannedComponent,
+    PublishOutcome,
+    RepoFacts,
+    WizardState,
+)
+
+
+def _facts(repo_root: Path) -> RepoFacts:
+    return RepoFacts(
+        repo_root=repo_root,
+        is_git=True,
+        remote_url="git@github.com:acme/widget.git",
+        suggested_repo_name="widget",
+        default_branch="main",
+        current_branch="main",
+        has_release_tags=False,
+        owner_repo_slug="acme/widget",
+    )
+
+
+def _lockfile(tmp_path: Path, rel: str, ecosystem: str = "python") -> DiscoveredLockfile:
+    return DiscoveredLockfile(
+        path=tmp_path / rel,
+        rel_path=Path(rel),
+        ecosystem=ecosystem,
+        suggested_name=rel.split("/")[-1],
+    )
+
+
+def _state(tmp_path: Path, *, formats: list[str] | None = None, augmentation: str = "skip") -> WizardState:
+    lock = _lockfile(tmp_path, "uv.lock")
+    state = WizardState(facts=_facts(tmp_path))
+    state.plan = Plan(
+        use_product_id="prod-1",
+        create_components=[PlannedComponent(lockfile=lock, name="widget-py")],
+        sbom_formats=formats or ["cyclonedx"],  # type: ignore[arg-type]
+        augmentation=augmentation,  # type: ignore[arg-type]
+    )
+    state.component_ids = {Path("uv.lock"): "comp-1"}
+    state.api = SimpleNamespace(token="sess-token")  # type: ignore[assignment]
+    return state
+
+
+def _opts(tmp_path: Path, *, dry_run: bool = False) -> WizardOptions:
+    return WizardOptions(
+        token="sess-token",
+        api_base_url="https://app.test",
+        repo_root=tmp_path,
+        output_dir=tmp_path / ".github" / "workflows",
+        dry_run=dry_run,
+    )
+
+
+@pytest.fixture()
+def out_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Route run_publish's mkdtemp into the test's tmp_path."""
+    target = tmp_path / "publish-out"
+    target.mkdir()
+    monkeypatch.setattr(publish_mod.tempfile, "mkdtemp", lambda prefix: str(target))
+    return target
+
+
+# ----------------------------------------------------------------------
+# matrix_rows / build_publish_runs
+
+
+def test_matrix_rows_single_component_single_format(tmp_path: Path) -> None:
+    rows = matrix_rows(
+        [PlannedComponent(lockfile=_lockfile(tmp_path, "uv.lock"), name="widget-py")],
+        ["cyclonedx"],
+        {"uv.lock": "comp-1"},
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.name == "widget-py"
+    assert row.component_id == "comp-1"
+    assert row.lockfile == "uv.lock"
+    assert row.output_file == "widget-py.cdx.json"
+
+
+def test_matrix_rows_multi_format_suffixes_name_and_extension(tmp_path: Path) -> None:
+    rows = matrix_rows(
+        [PlannedComponent(lockfile=_lockfile(tmp_path, "uv.lock"), name="widget-py")],
+        ["cyclonedx", "spdx"],
+        {"uv.lock": "comp-1"},
+    )
+    assert [r.name for r in rows] == ["widget-py-cyclonedx", "widget-py-spdx"]
+    assert [r.output_file for r in rows] == ["widget-py.cdx.json", "widget-py.spdx.json"]
+
+
+def test_matrix_rows_duplicate_names_disambiguated_by_lockfile_slug(tmp_path: Path) -> None:
+    rows = matrix_rows(
+        [
+            PlannedComponent(lockfile=_lockfile(tmp_path, "a/uv.lock"), name="widget"),
+            PlannedComponent(lockfile=_lockfile(tmp_path, "b/uv.lock"), name="widget"),
+        ],
+        ["cyclonedx"],
+        {"a/uv.lock": "c1", "b/uv.lock": "c2"},
+    )
+    outputs = [r.output_file for r in rows]
+    assert len(set(outputs)) == 2, f"duplicate output files: {outputs}"
+
+
+def test_build_publish_runs_places_outputs_in_output_dir(tmp_path: Path) -> None:
+    state = _state(tmp_path, formats=["cyclonedx", "spdx"])
+    runs = publish_mod.build_publish_runs(state, tmp_path / "out")
+    assert [r.output_path for r in runs] == [
+        tmp_path / "out" / "widget-py.cdx.json",
+        tmp_path / "out" / "widget-py.spdx.json",
+    ]
+    # Real IDs from apply, never the placeholder.
+    assert all(r.row.component_id == "comp-1" for r in runs)
+
+
+# ----------------------------------------------------------------------
+# _build_env
+
+
+def test_build_env_mirrors_workflow_env_with_session_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A stray pipeline var in the caller's environment must not leak in.
+    monkeypatch.setenv("DOCKER_IMAGE", "nginx:latest")
+    monkeypatch.setenv("SBOM_FILE", "stale.json")
+    monkeypatch.setenv("HOME", str(tmp_path))  # unrelated vars survive
+
+    state = _state(tmp_path, augmentation="profile")
+    state.plan.enrich = False
+    runs = publish_mod.build_publish_runs(state, tmp_path / "out")
+    env = publish_mod._build_env(runs[0], state, _opts(tmp_path), version="abc1234")
+
+    assert env["TOKEN"] == "sess-token"
+    assert env["COMPONENT_ID"] == "comp-1"
+    assert env["COMPONENT_NAME"] == "widget-py"
+    assert env["COMPONENT_VERSION"] == "abc1234"
+    assert env["LOCK_FILE"] == "uv.lock"
+    assert env["UPLOAD"] == "true"
+    assert env["AUGMENT"] == "true"  # profile → AUGMENT=true, same as the emitter
+    assert env["ENRICH"] == "false"
+    assert env["SBOM_FORMAT"] == "cyclonedx"
+    assert env["OUTPUT_FILE"] == str(tmp_path / "out" / "widget-py.cdx.json")
+    assert env["API_BASE_URL"] == "https://app.test"
+    assert "DOCKER_IMAGE" not in env
+    assert "SBOM_FILE" not in env
+    assert "PRODUCT_RELEASE" not in env  # releases stay CI's job
+    assert env["HOME"] == str(tmp_path)
+
+
+def test_build_env_omits_version_when_unknown(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    runs = publish_mod.build_publish_runs(state, tmp_path / "out")
+    env = publish_mod._build_env(runs[0], state, _opts(tmp_path), version=None)
+    assert "COMPONENT_VERSION" not in env
+
+
+# ----------------------------------------------------------------------
+# component_version
+
+
+def test_component_version_returns_short_sha(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        publish_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="abc1234\n"),
+    )
+    assert publish_mod.component_version(tmp_path) == "abc1234"
+
+
+def test_component_version_none_when_git_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        publish_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=128, stdout=""),
+    )
+    assert publish_mod.component_version(tmp_path) is None
+
+
+def test_component_version_none_when_git_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _boom(*a: object, **k: object) -> None:
+        raise OSError("git not found")
+
+    monkeypatch.setattr(publish_mod.subprocess, "run", _boom)
+    assert publish_mod.component_version(tmp_path) is None
+
+
+# ----------------------------------------------------------------------
+# _stream_subprocess — the real subprocess boundary
+
+
+def test_stream_subprocess_forwards_merged_output_and_exit_code(tmp_path: Path) -> None:
+    import sys
+
+    lines: list[str] = []
+    code = publish_mod._stream_subprocess(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('to stdout'); print('to stderr', file=sys.stderr); sys.exit(3)",
+        ],
+        env={"PATH": "/usr/bin:/bin"},
+        cwd=tmp_path,
+        on_line=lines.append,
+    )
+    assert code == 3
+    assert "to stdout" in lines
+    assert "to stderr" in lines  # stderr merged into stdout
+
+
+# ----------------------------------------------------------------------
+# run_publish
+
+
+def test_run_publish_success_records_ok_outcomes(
+    tmp_path: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state(tmp_path)
+    calls: list[dict] = []
+
+    def fake_stream(cmd: list[str], *, env: dict, cwd: Path, on_line) -> int:
+        calls.append({"cmd": cmd, "env": env, "cwd": cwd})
+        on_line("step 1 ok")
+        return 0
+
+    monkeypatch.setattr(publish_mod, "_stream_subprocess", fake_stream)
+    monkeypatch.setattr(publish_mod, "component_version", lambda _root: "abc1234")
+    logs: list[tuple[str, str]] = []
+
+    all_ok = publish_mod.run_publish(state, _opts(tmp_path), log=lambda k, m: logs.append((k, m)))
+
+    assert all_ok is True
+    assert state.publish_output_dir == out_dir
+    assert len(calls) == 1
+    assert calls[0]["cwd"] == tmp_path  # repo root: LOCK_FILE + sbomify.json resolve from here
+    assert calls[0]["cmd"][1:] == ["-c", publish_mod._PIPELINE_BOOTSTRAP]
+    assert calls[0]["env"]["TOKEN"] == "sess-token"
+    assert state.publish_outcomes == [
+        PublishOutcome(
+            rel_path="uv.lock",
+            sbom_format="cyclonedx",
+            output_file=out_dir / "widget-py.cdx.json",
+            ok=True,
+        )
+    ]
+    # Raw subprocess lines are forwarded with the "output" kind.
+    assert ("output", "step 1 ok") in logs
+    assert any(k == "success" and "Published" in m for k, m in logs)
+
+
+def test_run_publish_failure_continues_to_next_run(
+    tmp_path: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state(tmp_path, formats=["cyclonedx", "spdx"])
+    exit_codes = iter([1, 0])
+    monkeypatch.setattr(
+        publish_mod,
+        "_stream_subprocess",
+        lambda cmd, *, env, cwd, on_line: next(exit_codes),
+    )
+    monkeypatch.setattr(publish_mod, "component_version", lambda _root: None)
+    logs: list[tuple[str, str]] = []
+
+    all_ok = publish_mod.run_publish(state, _opts(tmp_path), log=lambda k, m: logs.append((k, m)))
+
+    assert all_ok is False
+    assert [o.ok for o in state.publish_outcomes] == [False, True]
+    assert state.publish_outcomes[0].error == "pipeline exited with code 1"
+    assert any(k == "warning" and "1 of 2" in m for k, m in logs)
+
+
+def test_run_publish_spawn_error_is_recorded_not_raised(
+    tmp_path: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state(tmp_path)
+
+    def _boom(cmd: list[str], *, env: dict, cwd: Path, on_line) -> int:
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(publish_mod, "_stream_subprocess", _boom)
+    monkeypatch.setattr(publish_mod, "component_version", lambda _root: None)
+
+    all_ok = publish_mod.run_publish(state, _opts(tmp_path))
+
+    assert all_ok is False
+    assert state.publish_outcomes[0].ok is False
+    assert "exec format error" in (state.publish_outcomes[0].error or "")
+
+
+def test_run_publish_dry_run_spawns_nothing(tmp_path: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _state(tmp_path)
+    state.is_dry_run = True
+    state.api = None  # dry-run must not need the API client
+
+    def _fail(*a: object, **k: object) -> int:
+        raise AssertionError("dry-run must not spawn a subprocess")
+
+    monkeypatch.setattr(publish_mod, "_stream_subprocess", _fail)
+    logs: list[tuple[str, str]] = []
+
+    all_ok = publish_mod.run_publish(state, _opts(tmp_path, dry_run=True), log=lambda k, m: logs.append((k, m)))
+
+    assert all_ok is True
+    assert [o.ok for o in state.publish_outcomes] == [True]
+    assert any("Would generate" in m for _k, m in logs)
+
+
+def test_run_publish_with_no_components_is_a_noop(
+    tmp_path: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _state(tmp_path)
+    state.plan.create_components = []
+    state.component_ids = {}
+    monkeypatch.setattr(
+        publish_mod,
+        "_stream_subprocess",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("nothing to run")),
+    )
+    logs: list[tuple[str, str]] = []
+
+    assert publish_mod.run_publish(state, _opts(tmp_path), log=lambda k, m: logs.append((k, m))) is True
+    assert state.publish_outcomes == []
+    assert any(k == "warning" for k, _m in logs)
+
+
+def test_reset_apply_artifacts_clears_publish_state(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.publish_outcomes = [
+        PublishOutcome(rel_path="uv.lock", sbom_format="cyclonedx", output_file=tmp_path / "x.json", ok=True)
+    ]
+    state.publish_output_dir = tmp_path
+
+    state.reset_apply_artifacts()
+
+    assert state.publish_outcomes == []
+    assert state.publish_output_dir is None
+
+
+# ----------------------------------------------------------------------
+# Publish screen — planned-runs text
+
+
+def test_publish_screen_planned_markup_lists_each_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from sbomify_action.cli.wizard.screens.publish import PublishScreen
+
+    state = _state(tmp_path, formats=["cyclonedx", "spdx"])
+    screen = PublishScreen.__new__(PublishScreen)  # bypass Textual Screen.__init__ (needs an app)
+    fake_wizard = SimpleNamespace(state=state, opts=_opts(tmp_path))
+    monkeypatch.setattr(PublishScreen, "wizard", property(lambda self: fake_wizard))
+
+    text = screen._planned_markup()
+
+    assert text.count("widget-py") == 2  # one line per (lockfile, format) row
+    assert "→ cyclonedx" in text
+    assert "→ spdx" in text
+    assert "Skipping is fine" in text
+
+
+# ----------------------------------------------------------------------
+# Done screen — published panel text
+
+
+def _done_screen(monkeypatch: pytest.MonkeyPatch, state: WizardState) -> DoneScreen:
+    screen = DoneScreen.__new__(DoneScreen)  # bypass Textual Screen.__init__ (needs an app)
+    fake_wizard = SimpleNamespace(state=state, opts=SimpleNamespace(api_base_url="https://app.test"))
+    monkeypatch.setattr(DoneScreen, "wizard", property(lambda self: fake_wizard))
+    return screen
+
+
+def test_published_summary_lists_successes_and_output_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.publish_output_dir = tmp_path / "out"
+    state.publish_outcomes = [
+        PublishOutcome(rel_path="uv.lock", sbom_format="cyclonedx", output_file=tmp_path / "w.cdx.json", ok=True)
+    ]
+
+    text = _done_screen(monkeypatch, state)._published_summary()
+
+    assert "Published" in text
+    assert "uv.lock" in text
+    assert str(tmp_path / "out") in text
+
+
+def test_published_summary_shows_failure_reason_and_ci_note(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.publish_outcomes = [
+        PublishOutcome(
+            rel_path="uv.lock",
+            sbom_format="cyclonedx",
+            output_file=tmp_path / "w.cdx.json",
+            ok=False,
+            error="pipeline exited with code 1",
+        )
+    ]
+
+    text = _done_screen(monkeypatch, state)._published_summary()
+
+    assert "Failed" in text
+    assert "pipeline exited with code 1" in text
+    assert "CI retries on the next push" in text
+
+
+def test_published_summary_dry_run_uses_would_publish_phrasing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.is_dry_run = True
+    state.publish_outcomes = [
+        PublishOutcome(rel_path="uv.lock", sbom_format="cyclonedx", output_file=tmp_path / "w.cdx.json", ok=True)
+    ]
+
+    text = _done_screen(monkeypatch, state)._published_summary()
+
+    assert "would publish" in text
+    assert "--dry-run" in text

--- a/tests/test_wizard_textual.py
+++ b/tests/test_wizard_textual.py
@@ -513,3 +513,92 @@ async def test_enter_on_focused_back_button_goes_back(tmp_path: Path, monkeypatc
         assert isinstance(app.screen, WelcomeScreen), (
             "Enter on focused Back button must pop the screen, not advance forward"
         )
+
+
+async def test_publish_screen_skip_advances_to_done_without_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skip must land on Done with publish_outcomes untouched, so the Done
+    screen renders exactly as it did before the Publish step existed."""
+    lockfiles = [
+        DiscoveredLockfile(
+            path=tmp_path / "uv.lock",
+            rel_path=Path("uv.lock"),
+            ecosystem="python",
+            suggested_name="widget-py",
+        )
+    ]
+    _stub_discovery(monkeypatch, lockfiles)
+
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test() as pilot:
+        # Stage state as if apply just finished.
+        from sbomify_action.cli.wizard.screens.done import DoneScreen
+        from sbomify_action.cli.wizard.screens.publish import PublishScreen
+        from sbomify_action.cli.wizard.state import PlannedComponent
+
+        app.state.plan.create_components = [PlannedComponent(lockfile=lockfiles[0], name="widget-py")]
+        app.state.component_ids = {Path("uv.lock"): "comp-1"}
+
+        app.push_screen(PublishScreen())
+        await pilot.pause()
+        assert isinstance(app.screen, PublishScreen)
+
+        from textual.widgets import Button
+
+        app.screen.query_one("#skip", Button).press()
+        await pilot.pause()
+
+        assert isinstance(app.screen, DoneScreen)
+        assert app.state.publish_outcomes == []
+
+
+async def test_publish_screen_runs_worker_then_continues_to_done(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Publish now → worker runs run_publish → button becomes Continue → Done."""
+    lockfiles = [
+        DiscoveredLockfile(
+            path=tmp_path / "uv.lock",
+            rel_path=Path("uv.lock"),
+            ecosystem="python",
+            suggested_name="widget-py",
+        )
+    ]
+    _stub_discovery(monkeypatch, lockfiles)
+
+    ran: list[object] = []
+
+    def fake_run_publish(state: object, opts: object, *, log: object) -> bool:
+        ran.append(state)
+        log("success", "Published widget-py (cyclonedx) to sbomify")
+        return True
+
+    monkeypatch.setattr("sbomify_action.cli.wizard.publish.run_publish", fake_run_publish)
+
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test() as pilot:
+        from sbomify_action.cli.wizard.screens.done import DoneScreen
+        from sbomify_action.cli.wizard.screens.publish import PublishScreen
+        from sbomify_action.cli.wizard.state import PlannedComponent
+
+        app.state.plan.create_components = [PlannedComponent(lockfile=lockfiles[0], name="widget-py")]
+        app.state.component_ids = {Path("uv.lock"): "comp-1"}
+
+        app.push_screen(PublishScreen())
+        await pilot.pause()
+
+        from textual.widgets import Button
+
+        app.screen.query_one("#publish", Button).press()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert ran, "run_publish was never invoked by the worker"
+        publish_btn = app.screen.query_one("#publish", Button)
+        assert str(publish_btn.label) == "Continue ▸"
+        assert publish_btn.disabled is False
+
+        publish_btn.press()
+        await pilot.pause()
+        assert isinstance(app.screen, DoneScreen)


### PR DESCRIPTION
## Summary

Expands the wizard with a final **Publish** step (step 9, between Apply and Done) that generates and uploads the first SBOMs right from the wizard, instead of waiting for the first CI run.

After Apply has created the components and written `sboms.yml`, the new screen lists one planned run per (lockfile, format) — the same matrix rows the emitted workflow runs in CI — and offers **Publish now / Skip / Back**. Each run executes the real pipeline as a subprocess, streaming its output live into the screen's log, and the Done screen gains a per-run published/failed panel.

## Design decisions

- **Subprocess, not in-process** — `run_pipeline` calls `sys.exit` on failure, reconfigures global logging, and mutates process-wide audit state, none of which can happen inside the Textual app. A subprocess also exercises exactly the code path CI will run. Known pipeline env vars are scrubbed from the inherited environment so a stray `DOCKER_IMAGE` in the user's shell can't hijack a run.
- **Credentials** — CI authenticates via OIDC or the repo secret; the local run reuses the session token the user already entered on the Authenticate screen. No extra setup.
- **Naming parity** — the matrix-row logic is factored out of `ci_emitter._matrix_block` into a shared `matrix_rows()` helper, so local runs and the CI job agree byte-for-byte on component IDs, output filenames, and duplicate-name slug disambiguation.
- **Best-effort and optional** — the step waits for an explicit button press (runs can take minutes), a failed run never blocks the remaining ones or the wizard (CI retries on the next push, and the UI says so), and Skip leaves the Done screen exactly as it was before this feature. `--dry-run` previews the runs without spawning anything.
- **Versioning** — locally published SBOMs are stamped with the short git SHA, matching the workflow's non-tag fallback. `PRODUCT_RELEASE` is deliberately not set locally so onboarding never cuts a surprise product release named after a commit SHA.
- **Output hygiene** — generated files go to a kept temp dir (surfaced on the Done screen), never the working tree; the subprocess runs with `cwd=repo_root` so repo-relative lockfile paths and `sbomify.json` augmentation resolve the same way they do in CI.

## Test plan

- New `tests/test_wizard_publish.py`: matrix-row parity, env building + scrubbing, dry-run, per-run failure isolation, spawn-error handling, real `_stream_subprocess` round-trip, Done-panel text variants.
- Two new Textual pilot tests: Publish screen composes, Skip → Done with no outcomes, Publish → worker → Continue → Done.
- Full suite: 2,440 passed, ruff clean. New runner module at 100% coverage, new screen at 81%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)