### PR TITLE
feat(hbom): allow release tagging for non-SBOM artifacts, and document HBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 - **Enrich** with package metadata from PyPI, pub.dev, crates.io, Conan Center, deps.dev, and more
 - **Audit Trail** — Every SBOM modification logged with timestamps for attestation and compliance
 - **Upload** to sbomify for collaboration and vulnerability management
+- **Pass through** pre-authored VEX, CBOM and HBOM artifacts verbatim, with no rewriting
 - **Tag** SBOMs with product releases
 - **Attest** with GitHub's build provenance
 
@@ -317,7 +318,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim to sbomify only (augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped; `dependency-track` in `UPLOAD_DESTINATIONS` and `PRODUCT_RELEASE` are rejected). Note: sbomify auto-classifies CycloneDX documents containing cryptographic assets as `cbom` |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim to sbomify only (augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped; `dependency-track` in `UPLOAD_DESTINATIONS` is rejected). Note: sbomify auto-classifies CycloneDX documents containing cryptographic assets as `cbom` |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |
@@ -405,6 +406,28 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
 ```
 
 </details>
+
+### Hardware BOM (HBOM)
+
+A hardware BOM lists the physical parts of a product: connectors, chips, PCBs. In CycloneDX it is a document whose components are `type: device`. An SBOM tells you what code ships; an HBOM tells you what is on the board.
+
+The action does not generate one. It uploads an HBOM you already have, byte for byte.
+
+```yaml
+- uses: sbomify/sbomify-action@master
+  env:
+    TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+    COMPONENT_ID: 'your-component-id'
+    BOM_TYPE: 'hbom'
+    SBOM_FILE: 'hardware/mainboard.hbom.cdx.json'
+    PRODUCT_RELEASE: '["my-product:v1.2.3"]'
+```
+
+**Where an HBOM comes from.** Usually a hardware BOM export from your PLM or EDA tooling, converted to CycloneDX. The [cdx-hbom](https://github.com/cdxgen/cdx-hbom) project from the [cdxgen](https://github.com/cdxgen/cdxgen) authors can also produce one, though check its scope first: it inventories the machine it runs on (CPU, disks, PCI and USB devices), so you get an asset record of a host rather than a parts list for a product you manufacture. If you build hardware, the document comes from your own design data.
+
+**Verbatim upload.** sbomify stores an HBOM exactly as you authored it, the same as VEX and CBOM. The action skips augmentation, enrichment, name and version overrides, and additional-package injection; setting `AUGMENT` or `ENRICH` logs a warning and continues rather than failing the run. Part numbers are the document's whole value, and a rewritten one is a different parts list.
+
+SPDX has no device component type, so `BOM_TYPE=hbom` requires CycloneDX. The action refuses an SPDX file before it uploads.
 
 ## Supported Lockfiles
 

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -364,12 +364,14 @@ class Config:
                         f"BOM_TYPE='{self.bom_type}' can only be uploaded to sbomify; remove "
                         f"{', '.join(non_sbomify)} from UPLOAD_DESTINATIONS."
                     )
-            # A release holds one SBOM per component and format; tagging a non-SBOM artifact
-            # would either collide with the component's SBOM or wrongly occupy its slot.
-            if self.product_releases:
-                raise ConfigurationError(
-                    f"BOM_TYPE='{self.bom_type}' cannot be tagged into a product release; remove PRODUCT_RELEASE."
-                )
+            # PRODUCT_RELEASE is allowed for every bom_type. A release slot is keyed on
+            # (component, format, bom_type), so a CBOM, VEX or HBOM occupies its own slot
+            # and cannot displace the component's SBOM; the backend's replace path filters
+            # on bom_type for the same reason, and ReleaseArtifact is unique per
+            # (release, artifact) rather than per component and format. An earlier version
+            # of this check assumed one SBOM per component and format and refused the whole
+            # combination, which left a hardware or crypto BOM unable to be part of the
+            # release it ships in.
             has_real_sbom_file = bool(self.sbom_file and self.sbom_file.lower() != NONE_SENTINEL)
             if self.lock_file or self.docker_image or not has_real_sbom_file:
                 raise ConfigurationError(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,20 +159,25 @@ class TestConfig(unittest.TestCase):
             config.validate()
         self.assertIn("dependency-track", str(cm.exception))
 
-    def test_bom_type_non_sbom_rejects_product_release(self):
-        """Releases hold one SBOM per component and format; tagging a VEX/CBOM
-        into a release either collides with the component's SBOM or occupies
-        its slot, so PRODUCT_RELEASE is rejected for non-SBOM artifacts."""
-        config = Config(
-            token="test-token",
-            component_id="test-component",
-            bom_type="vex",
-            sbom_file="/path/to/authored.vex.cdx.json",
-            product_releases='["myproduct:v1.0.0"]',
-        )
-        with self.assertRaises(ConfigurationError) as cm:
-            config.validate()
-        self.assertIn("PRODUCT_RELEASE", str(cm.exception))
+    def test_bom_type_non_sbom_allows_product_release(self):
+        """A release slot is keyed on (component, format, bom_type), so a VEX,
+        CBOM or HBOM occupies its own slot and cannot displace the component's
+        SBOM. This was rejected on the assumption of one SBOM per component and
+        format, which left a hardware or crypto BOM unable to be part of the
+        release it ships in."""
+        for bom_type in ("vex", "cbom", "hbom"):
+            with self.subTest(bom_type=bom_type):
+                config = Config(
+                    token="test-token",
+                    component_id="test-component",
+                    bom_type=bom_type,
+                    sbom_file=f"/path/to/authored.{bom_type}.cdx.json",
+                    product_releases='["myproduct:v1.0.0"]',
+                )
+
+                config.validate()
+
+                self.assertEqual(config.product_releases, ["myproduct:v1.0.0"])
 
     def test_bom_type_non_sbom_no_upload_allows_other_destinations(self):
         """With UPLOAD=false nothing is sent anywhere, so configured

--- a/tests/test_pipeline_bom_type.py
+++ b/tests/test_pipeline_bom_type.py
@@ -176,3 +176,117 @@ def test_pipeline_openvex_rejected_without_vex_bom_type(tmp_path, monkeypatch):
     with pytest.raises(SystemExit) as exc:
         run_pipeline(config)
     assert exc.value.code == 1
+
+
+# A hardware BOM: every component is type=device, which is what makes the
+# document an HBOM rather than a device's software SBOM. Deliberately awkward
+# bytes — CRLF, an odd document version, unsorted keys — so "verbatim" is
+# testable rather than merely asserted.
+AUTHORED_HBOM = (
+    b'{"bomFormat": "CycloneDX",\r\n'
+    b'  "specVersion": "1.6",\n'
+    b'  "version": 4,\n'
+    b'  "metadata": {"component": {"type": "device", "bom-ref": "board", "name": "PCIe-SATA adapter"}},\n'
+    b'  "components": [\n'
+    b'    {"type": "device", "bom-ref": "J1", "name": "PCIE-098-02-F-D-EMS2",\n'
+    b'     "supplier": {"name": "Samtec"}, "version": "2.9.10"},\n'
+    b'    {"type": "device", "bom-ref": "J2", "name": "47155-4001", "supplier": {"name": "Molex"}}]}\n'
+)
+
+
+def _hbom_config(tmp_path, monkeypatch, **overrides):
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "authored.hbom.cdx.json"
+    src.write_bytes(AUTHORED_HBOM)
+    kwargs = dict(
+        sbom_file=str(src),
+        upload=False,
+        bom_type="hbom",
+        output_file="out.hbom.json",
+    )
+    kwargs.update(overrides)
+    return build_config(**kwargs), src
+
+
+def test_pipeline_hbom_verbatim_end_to_end(tmp_path, monkeypatch):
+    """A hardware BOM survives the pipeline byte for byte.
+
+    The action cannot generate an HBOM, so the only thing it can do wrong is
+    change one — and the parts list is the document's whole value. Additional
+    package injection is configured to prove it does not reach a passthrough.
+    """
+    monkeypatch.setenv("ADDITIONAL_PACKAGES", "extra-package==1.0.0")
+    config, _ = _hbom_config(tmp_path, monkeypatch)
+
+    run_pipeline(config)
+
+    assert (tmp_path / "out.hbom.json").read_bytes() == AUTHORED_HBOM
+
+
+def test_pipeline_hbom_forces_augment_and_enrich_off(tmp_path, monkeypatch):
+    """Both rewrite the document, so the verbatim contract requires them off.
+    They are refused quietly at config time rather than failing the run: a user
+    who set them globally should still get their HBOM uploaded."""
+    config, _ = _hbom_config(tmp_path, monkeypatch, augment=True, enrich=True)
+
+    assert config.augment is False
+    assert config.enrich is False
+
+    run_pipeline(config)
+
+    assert (tmp_path / "out.hbom.json").read_bytes() == AUTHORED_HBOM
+
+
+def test_hbom_uploads_with_the_bom_type_query_parameter(tmp_path, monkeypatch):
+    """bom_type reaches the backend as a query parameter; without it the
+    artifact is stored as a plain SBOM and takes the component's SBOM slot."""
+    from sbomify_action.sbomify_api import SbomifyApiClient
+
+    captured: dict[str, object] = {}
+
+    def _capture(method, path, **kwargs):
+        captured.update(method=method, path=path, params=kwargs.get("params"))
+        return None
+
+    api = SbomifyApiClient(base_url="https://example.test", token="t")  # nosec B106 - test stub, not a credential
+    monkeypatch.setattr(api, "_request", _capture)
+
+    api.upload_sbom(component_id="comp123", sbom_payload=b'{"bomFormat": "CycloneDX"}', bom_type="hbom")
+
+    assert captured["params"] == {"bom_type": "hbom"}
+    assert "artifact/cyclonedx/comp123" in str(captured["path"])
+
+
+def test_hbom_with_spdx_content_is_refused(tmp_path, monkeypatch):
+    """SPDX has no device component type and the backend rejects bom_type=hbom
+    for it, so the run has to fail here rather than at upload."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "doc.json"
+    src.write_bytes(b'{"spdxVersion": "SPDX-2.3", "name": "x", "packages": []}')
+    config = build_config(sbom_file=str(src), upload=False, bom_type="hbom", output_file="out.json")
+
+    with pytest.raises(SystemExit) as exc:
+        run_pipeline(config)
+
+    assert exc.value.code == 1
+
+
+def test_hbom_can_be_tagged_into_a_product_release(tmp_path, monkeypatch):
+    """A release slot is keyed on (component, format, bom_type), so an HBOM
+    occupies its own slot rather than the component's SBOM slot. This
+    combination used to be refused at config time, which left a hardware BOM
+    unable to be part of the release it ships in."""
+    config, _ = _hbom_config(
+        tmp_path,
+        monkeypatch,
+        component_id="comp123",
+        product_releases='["myproduct:v1.2.3"]',
+        token="test-token",  # nosec B106 - PRODUCT_RELEASE requires one; never sent, upload is off
+    )
+
+    assert config.product_releases == ["myproduct:v1.2.3"]
+    assert config.bom_type == "hbom"
+
+    run_pipeline(config)
+
+    assert (tmp_path / "out.hbom.json").read_bytes() == AUTHORED_HBOM


### PR DESCRIPTION
Closes #321, closes #322, closes #323.

**#324 is not here** — its body reads `Status: file, do not start.` The wizard's job is getting a first SBOM flowing, and no user has asked for `BOM_TYPE` in the guided flow.

## #323 is a real defect, not a missing nicety

`PRODUCT_RELEASE` was refused for every non-SBOM `bom_type`, on the stated grounds that "a release holds one SBOM per component and format; tagging a non-SBOM artifact would either collide with the component's SBOM or wrongly occupy its slot."

The issue asked to confirm the constraint with the backend before merging. I checked all three claims against it rather than taking the issue's word:

- `Release.get_latest_sboms_by_format` keys the slot on `(format, bom_type)`, with a comment saying it is that way precisely so a CBOM or VEX "each keep their own latest slot instead of one displacing the other"
- `add_artifact_to_release` filters the replace path on `sbom__bom_type`, commented "so a CBOM/VEX (same cyclonedx format) only replaces its own kind and never evicts the component's real SBOM from the release"
- `ReleaseArtifact.unique_together` is `(release, sbom)` and `(release, document)` — per artifact, not per component and format

So the collision the check guarded against is the thing the backend is built to prevent. The effect of the check was that a hardware or crypto BOM could not be part of the release it ships in, which is most of the reason to upload one. It blocked `vex` and `cbom` identically.

## #321 coverage

`tests/test_pipeline_bom_type.py` claimed VEX, CBOM and HBOM in its docstring and every test in it was VEX. Adds, for a CycloneDX device BOM: byte-identical passthrough (with `ADDITIONAL_PACKAGES` set, to prove injection does not reach a passthrough), `AUGMENT`/`ENRICH` forced off, `?bom_type=hbom` reaching the API, SPDX content refused, and an HBOM tagged into a release.

The fixture uses deliberately awkward bytes — CRLF, an odd document `version`, unsorted keys — so "verbatim" is testable rather than asserted.

The config test that asserted the old rejection is replaced by one covering `vex`, `cbom` and `hbom` positively.

## #322 README

An HBOM section with a working workflow example, plus a features bullet for verbatim passthrough. It also corrects the `BOM_TYPE` table row, which still said `PRODUCT_RELEASE` was rejected.

Two things I changed from the issue's wording. It says to link cdxgen; the HBOM command lives in a separate **[cdx-hbom](https://github.com/cdxgen/cdx-hbom)** project, and the `CycloneDX/cdxgen` URL now 301s because the project moved to the `cdxgen` org. Both links in the section return 200.

The section states cdx-hbom's scope plainly — it inventories the machine it runs on, so it yields an asset record of a host rather than a parts list for a product you manufacture — so nobody reaches for it expecting the latter.

## Testing

2447 pass, 4 skipped. Ruff clean.

