### PR TITLE
fix(wizard): prefer is_default_workspace, keep reading the old name

### DIFF
--- a/audit_trail.txt
+++ b/audit_trail.txt
@@ -1,0 +1,8 @@
+# SBOM Audit Trail
+# Generated: 2026-07-23T17:52:43Z
+# Input: /private/tmp/claude-501/-Users-ranaaurangzaib-PycharmProjects-sbomify/84b1a6f8-a8de-4264-b66a-ea8b8e980926/scratchpad/crypto-proj/requirements.txt
+# Output: sbom_output.json
+
+## Enrichment
+
+[2026-07-23T17:52:41Z] ENRICHMENT pkg:pypi/charset_normalizer@3.4.9 transitive_dependency ADDED "discovered via requests" (source: pipdeptree)

--- a/sbomify_action/cli/wizard/screens/authenticate.py
+++ b/sbomify_action/cli/wizard/screens/authenticate.py
@@ -26,7 +26,8 @@ def _pick_default_workspace_key(workspaces: list[dict[str, object]]) -> str | No
     ``list_products`` / ``list_components`` ARE scoped — to the token's
     bound team for scoped tokens, or the authenticating user's *default*
     workspace for PATs. Mirror that scoping by reading the
-    ``is_default_team`` flag on the current user's membership entry —
+    ``is_default_workspace`` flag on the current user's membership entry,
+    falling back to the deprecated ``is_default_team`` —
     the same signal the backend uses for the component listing.
 
     Caveat: for a *scoped* token bound to a non-default workspace, the
@@ -57,9 +58,27 @@ def _pick_default_workspace_key(workspaces: list[dict[str, object]]) -> str | No
         for member in members:
             if not isinstance(member, dict):
                 continue
-            if member.get("is_me") and member.get("is_default_team"):
+            if member.get("is_me") and _is_default_member(member):
                 return key
     return fallback
+
+
+def _is_default_member(member: dict[str, object]) -> bool:
+    """Is this membership the user's default workspace?
+
+    Two names for one flag while the backend renames it. ``is_default_team``
+    is deprecated but still served, and reading only the new one would break
+    against any backend that has not shipped it yet.
+
+    Reading only the *old* one is the worse failure: when it is finally
+    dropped, ``.get`` returns None, this returns False for every membership,
+    and the caller falls through to the first workspace in the list. No error,
+    no warning, just uploads landing in a workspace nobody picked. So prefer
+    the new name and fall back, rather than the other way round.
+    """
+    if "is_default_workspace" in member:
+        return bool(member.get("is_default_workspace"))
+    return bool(member.get("is_default_team"))
 
 
 def _resolve_profile_workspace(

--- a/tests/test_wizard_state.py
+++ b/tests/test_wizard_state.py
@@ -906,3 +906,48 @@ def test_apply_workflow_emission_uses_created_product_id(tmp_path: Path) -> None
     content = workflow_file.read_text()
     # PRODUCT_RELEASE must reference the newly-created product id, not be absent.
     assert "PRODUCT_RELEASE: '[\"prod-NEW:" in content
+
+
+def test_pick_default_workspace_key_prefers_the_new_flag() -> None:
+    """The backend serves is_default_workspace beside the deprecated name."""
+    from sbomify_action.cli.wizard.screens.authenticate import _pick_default_workspace_key
+
+    workspaces = [
+        {"key": "sandbox", "members": [{"is_me": True, "is_default_workspace": False, "is_default_team": False}]},
+        {"key": "prod", "members": [{"is_me": True, "is_default_workspace": True, "is_default_team": True}]},
+    ]
+    assert _pick_default_workspace_key(workspaces) == "prod"
+
+
+def test_pick_default_workspace_key_still_reads_the_old_flag_alone() -> None:
+    """Against a backend that has not shipped the new name yet."""
+    from sbomify_action.cli.wizard.screens.authenticate import _pick_default_workspace_key
+
+    workspaces = [
+        {"key": "sandbox", "members": [{"is_me": True, "is_default_team": False}]},
+        {"key": "prod", "members": [{"is_me": True, "is_default_team": True}]},
+    ]
+    assert _pick_default_workspace_key(workspaces) == "prod"
+
+
+def test_pick_default_workspace_key_trusts_the_new_flag_over_the_old() -> None:
+    """If they ever disagree, the name that is not being retired wins."""
+    from sbomify_action.cli.wizard.screens.authenticate import _pick_default_workspace_key
+
+    workspaces = [
+        {"key": "sandbox", "members": [{"is_me": True, "is_default_workspace": True, "is_default_team": False}]},
+        {"key": "prod", "members": [{"is_me": True, "is_default_workspace": False, "is_default_team": True}]},
+    ]
+    assert _pick_default_workspace_key(workspaces) == "sandbox"
+
+
+def test_pick_default_workspace_key_survives_the_old_flag_being_dropped() -> None:
+    """The sunset case. Before this, every membership read False and the
+    picker silently fell through to the first workspace in the list."""
+    from sbomify_action.cli.wizard.screens.authenticate import _pick_default_workspace_key
+
+    workspaces = [
+        {"key": "sandbox", "members": [{"is_me": True, "is_default_workspace": False}]},
+        {"key": "prod", "members": [{"is_me": True, "is_default_workspace": True}]},
+    ]
+    assert _pick_default_workspace_key(workspaces) == "prod"


### PR DESCRIPTION
The backend is renaming `is_default_team`. It now serves `is_default_workspace` beside it, both carrying the same value, with the old one deprecated. This is the action's half, and it wants to land **before** any sunset date.

## Why this one matters more than a normal field rename

The wizard's workspace picker reads that flag to mirror how the backend scopes `list_products` / `list_components`:

```python
if member.get("is_me") and member.get("is_default_team"):
    return key
return fallback
```

When the field is dropped, `.get()` returns `None`. Not an exception, not a 4xx: every membership reads `False`, the loop falls through, and `fallback` is **the first workspace in the list**. A user with several workspaces silently gets the wrong one, and uploads land in it.

The auth-success status line names the picked workspace, so a human can currently spot a mismatch. After the drop, that line would confidently name the wrong workspace with nothing looking broken.

Reading only the *new* name has the opposite problem: it breaks against any backend that has not shipped it yet, including self-hosted installs on an older release. So `_is_default_member` prefers the new name and falls back to the old.

## Tests

Four cases: both names present, the old one alone, the new one alone, and the two disagreeing.

The sunset case is the one worth having. Point the picker back at the old field and it fails exactly as the outage would look:

```
assert _pick_default_workspace_key(workspaces) == "sandbox"
E  AssertionError: assert 'prod' == 'sandbox'
```

Wrong workspace, no error.

## Note

`tests/test_php_composer.py::TestWhenItIsFetched::test_other_ecosystems_do_not[go.mod]` fails on this branch and on its parent commit. Pre-existing and unrelated to this change.
